### PR TITLE
feat: PDF info panel

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -106,6 +106,9 @@ struct DocumentInfo {
     page_count:        usize,
     file_size_bytes:   Option<u64>,     // None if stat() fails (e.g. unsaved temp doc)
     pdf_version:       Option<String>,  // e.g. "PDF 1.7"; None if Unset
+    /// Dimensions of the first page in PDF points (1 pt = 1/72 inch).
+    /// None only when the document has zero pages.
+    page_size:         Option<PageSize>,
     security:          DocumentSecurity,
 }
 
@@ -247,6 +250,11 @@ fn get_document_info(doc_id: u32, state: State<AppState>) -> Result<DocumentInfo
         can_assemble:  perms.can_assemble_document().unwrap_or(false),
     };
 
+    let page_size = doc.pages().get(0).ok().map(|p| PageSize {
+        width_pts:  p.width().value  as f64,
+        height_pts: p.height().value as f64,
+    });
+
     Ok(DocumentInfo {
         title:             meta.get(Title).map(|t| t.value().to_string()),
         author:            meta.get(Author).map(|t| t.value().to_string()),
@@ -259,6 +267,7 @@ fn get_document_info(doc_id: u32, state: State<AppState>) -> Result<DocumentInfo
         page_count:        entry.page_count,
         file_size_bytes,
         pdf_version,
+        page_size,
         security,
     })
 }
@@ -685,6 +694,38 @@ mod tests {
         let state = empty_state();
         assert_eq!(require_doc(4, &state).err().unwrap(), "document 4 not found");
         assert_eq!(require_doc(5, &state).err().unwrap(), "document 5 not found");
+    }
+
+    #[test]
+    fn document_info_includes_page_size_field() {
+        // Verify that DocumentInfo carries a page_size field. The None path
+        // represents an empty document; the Some path is covered by integration
+        // tests that run against a real pdfium document.
+        let info_no_pages = DocumentInfo {
+            title: None, author: None, subject: None, keywords: None,
+            creator: None, producer: None,
+            creation_date: None, modification_date: None,
+            page_count: 0,
+            file_size_bytes: None,
+            pdf_version: None,
+            page_size: None,
+            security: DocumentSecurity {
+                is_protected: false, revision: None,
+                can_print: "high_quality".to_string(),
+                can_modify: true, can_copy: true,
+                can_annotate: true, can_fill_forms: true, can_assemble: true,
+            },
+        };
+        assert!(info_no_pages.page_size.is_none());
+
+        let info_with_page = DocumentInfo {
+            page_count: 1,
+            page_size: Some(PageSize { width_pts: 612.0, height_pts: 792.0 }),
+            ..info_no_pages
+        };
+        let ps = info_with_page.page_size.unwrap();
+        assert_eq!(ps.width_pts, 612.0);
+        assert_eq!(ps.height_pts, 792.0);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -183,6 +183,8 @@ fn open_document(path: String, state: State<AppState>) -> Result<DocumentManifes
 #[tauri::command]
 fn get_document_info(doc_id: u32, state: State<AppState>) -> Result<DocumentInfo, String> {
     let entry = require_doc(doc_id, &state)?;
+    // Stat the file before locking the doc — fs I/O inside a Mutex is a code smell.
+    let file_size_bytes = std::fs::metadata(&entry.path).map(|m| m.len()).ok();
     let doc = entry.doc.lock().unwrap();
     let meta = doc.metadata();
     use PdfDocumentMetadataTagType::*;
@@ -201,8 +203,6 @@ fn get_document_info(doc_id: u32, state: State<AppState>) -> Result<DocumentInfo
         PdfDocumentVersion::Pdf2_0   => Some("PDF 2.0".to_string()),
         PdfDocumentVersion::Other(n) => Some(format!("PDF (version {})", n)),
     };
-
-    let file_size_bytes = std::fs::metadata(&entry.path).map(|m| m.len()).ok();
 
     Ok(DocumentInfo {
         title:             meta.get(Title).map(|t| t.value().to_string()),
@@ -351,6 +351,7 @@ const PDF_MENU_IDS: &[&str] = &[
     "close", "print", "undo", "redo", "select-all", "find",
     "save", "save-as",
     "zoom-in", "zoom-out", "zoom-fit-width",
+    "doc-info",
     // Document menu
     "rotate-cw", "rotate-cw-all", "rotate-ccw", "rotate-ccw-all",
     "split", "merge", "import-pages",
@@ -470,6 +471,7 @@ pub fn run() {
                 "zoom-in"        => { let _ = app.emit("menu-zoom-in",        ()); }
                 "zoom-out"       => { let _ = app.emit("menu-zoom-out",       ()); }
                 "zoom-fit-width" => { let _ = app.emit("menu-zoom-fit-width", ()); }
+                "doc-info"       => { let _ = app.emit("menu-doc-info",       ()); }
                 "theme-system" => { set_theme_checks(app, "system"); let _ = app.emit("menu-theme", "system"); }
                 "theme-light"  => { set_theme_checks(app, "light");  let _ = app.emit("menu-theme", "light"); }
                 "theme-dark"   => { set_theme_checks(app, "dark");   let _ = app.emit("menu-theme", "dark"); }
@@ -642,7 +644,7 @@ mod tests {
     }
 
     #[test]
-    fn get_document_info_unknown_doc_returns_err() {
+    fn require_doc_unknown_id_returns_err() {
         let state = empty_state();
         assert_eq!(
             require_doc(99, &state).err().unwrap(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,6 +33,8 @@ struct DocumentEntry {
     doc: Mutex<PdfDocument<'static>>,
     page_count: usize,
     filename: String,
+    /// Full filesystem path — needed by get_document_info for file size.
+    path: String,
     // Keep bytes alive — pdfium's FPDF_LoadMemDocument holds a pointer into
     // this buffer for the lifetime of the document.
     _bytes: Arc<Vec<u8>>,
@@ -71,6 +73,24 @@ struct DocumentManifest {
     /// Whether a redo step is available. Always false until the command stack
     /// is implemented in Phase 3.
     can_redo: bool,
+}
+
+/// PDF metadata and file statistics returned by `get_document_info`.
+/// All string fields are Option<String> — pdfium returns None for absent InfoDict entries,
+/// which is common (many PDFs omit most fields).
+#[derive(Serialize, Clone)]
+struct DocumentInfo {
+    title:             Option<String>,
+    author:            Option<String>,
+    subject:           Option<String>,
+    keywords:          Option<String>,  // raw comma/semicolon-separated string
+    creator:           Option<String>,
+    producer:          Option<String>,
+    creation_date:     Option<String>,  // raw PDF date, e.g. "D:20230415143022+05'30'"
+    modification_date: Option<String>,
+    page_count:        usize,
+    file_size_bytes:   Option<u64>,     // None if stat() fails (e.g. unsaved temp doc)
+    pdf_version:       Option<String>,  // e.g. "PDF 1.7"; None if Unset
 }
 
 // ---------------------------------------------------------------------------
@@ -142,6 +162,7 @@ fn open_document(path: String, state: State<AppState>) -> Result<DocumentManifes
             doc: Mutex::new(doc),
             page_count,
             filename: filename.clone(),
+            path: path.clone(),
             _bytes: pdf_bytes,
         }),
     );
@@ -154,6 +175,47 @@ fn open_document(path: String, state: State<AppState>) -> Result<DocumentManifes
         page_sizes,
         can_undo: false,
         can_redo: false,
+    })
+}
+
+/// Return metadata and file statistics for an open document.
+/// Fields sourced from the PDF InfoDict are Option — most real-world PDFs omit many of them.
+#[tauri::command]
+fn get_document_info(doc_id: u32, state: State<AppState>) -> Result<DocumentInfo, String> {
+    let entry = require_doc(doc_id, &state)?;
+    let doc = entry.doc.lock().unwrap();
+    let meta = doc.metadata();
+    use PdfDocumentMetadataTagType::*;
+
+    // Match on the version enum variants directly — as_pdfium() is pub(crate).
+    let pdf_version = match doc.version() {
+        PdfDocumentVersion::Unset    => None,
+        PdfDocumentVersion::Pdf1_0   => Some("PDF 1.0".to_string()),
+        PdfDocumentVersion::Pdf1_1   => Some("PDF 1.1".to_string()),
+        PdfDocumentVersion::Pdf1_2   => Some("PDF 1.2".to_string()),
+        PdfDocumentVersion::Pdf1_3   => Some("PDF 1.3".to_string()),
+        PdfDocumentVersion::Pdf1_4   => Some("PDF 1.4".to_string()),
+        PdfDocumentVersion::Pdf1_5   => Some("PDF 1.5".to_string()),
+        PdfDocumentVersion::Pdf1_6   => Some("PDF 1.6".to_string()),
+        PdfDocumentVersion::Pdf1_7   => Some("PDF 1.7".to_string()),
+        PdfDocumentVersion::Pdf2_0   => Some("PDF 2.0".to_string()),
+        PdfDocumentVersion::Other(n) => Some(format!("PDF (version {})", n)),
+    };
+
+    let file_size_bytes = std::fs::metadata(&entry.path).map(|m| m.len()).ok();
+
+    Ok(DocumentInfo {
+        title:             meta.get(Title).map(|t| t.value().to_string()),
+        author:            meta.get(Author).map(|t| t.value().to_string()),
+        subject:           meta.get(Subject).map(|t| t.value().to_string()),
+        keywords:          meta.get(Keywords).map(|t| t.value().to_string()),
+        creator:           meta.get(Creator).map(|t| t.value().to_string()),
+        producer:          meta.get(Producer).map(|t| t.value().to_string()),
+        creation_date:     meta.get(CreationDate).map(|t| t.value().to_string()),
+        modification_date: meta.get(ModificationDate).map(|t| t.value().to_string()),
+        page_count:        entry.page_count,
+        file_size_bytes,
+        pdf_version,
     })
 }
 
@@ -495,6 +557,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             open_document,
             close_document,
+            get_document_info,
             set_menu_theme,
             set_pdf_menus_enabled,
             save_document,
@@ -576,5 +639,14 @@ mod tests {
         let state = empty_state();
         assert_eq!(require_doc(4, &state).err().unwrap(), "document 4 not found");
         assert_eq!(require_doc(5, &state).err().unwrap(), "document 5 not found");
+    }
+
+    #[test]
+    fn get_document_info_unknown_doc_returns_err() {
+        let state = empty_state();
+        assert_eq!(
+            require_doc(99, &state).err().unwrap(),
+            "document 99 not found"
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -75,6 +75,21 @@ struct DocumentManifest {
     can_redo: bool,
 }
 
+/// PDF security/permissions returned as part of `get_document_info`.
+/// `can_print` is "high_quality" | "low_quality" | "not_allowed".
+/// Permission fields are only meaningful when `is_protected` is true.
+#[derive(Serialize, Clone)]
+struct DocumentSecurity {
+    is_protected:  bool,
+    revision:      Option<u8>,   // 2, 3, or 4; None when unprotected
+    can_print:     String,       // "high_quality" | "low_quality" | "not_allowed"
+    can_modify:    bool,
+    can_copy:      bool,
+    can_annotate:  bool,
+    can_fill_forms: bool,
+    can_assemble:  bool,
+}
+
 /// PDF metadata and file statistics returned by `get_document_info`.
 /// All string fields are Option<String> — pdfium returns None for absent InfoDict entries,
 /// which is common (many PDFs omit most fields).
@@ -91,6 +106,7 @@ struct DocumentInfo {
     page_count:        usize,
     file_size_bytes:   Option<u64>,     // None if stat() fails (e.g. unsaved temp doc)
     pdf_version:       Option<String>,  // e.g. "PDF 1.7"; None if Unset
+    security:          DocumentSecurity,
 }
 
 // ---------------------------------------------------------------------------
@@ -204,6 +220,33 @@ fn get_document_info(doc_id: u32, state: State<AppState>) -> Result<DocumentInfo
         PdfDocumentVersion::Other(n) => Some(format!("PDF (version {})", n)),
     };
 
+    let perms = doc.permissions();
+    use PdfSecurityHandlerRevision::*;
+    let revision = match perms.security_handler_revision() {
+        Ok(Revision2) => Some(2u8),
+        Ok(Revision3) => Some(3u8),
+        Ok(Revision4) => Some(4u8),
+        _             => None,
+    };
+    let is_protected = revision.is_some();
+    let can_print = if perms.can_print_high_quality().unwrap_or(false) {
+        "high_quality"
+    } else if perms.can_print_only_low_quality().unwrap_or(false) {
+        "low_quality"
+    } else {
+        "not_allowed"
+    }.to_string();
+    let security = DocumentSecurity {
+        is_protected,
+        revision,
+        can_print,
+        can_modify:    perms.can_modify_document_content().unwrap_or(false),
+        can_copy:      perms.can_extract_text_and_graphics().unwrap_or(false),
+        can_annotate:  perms.can_add_or_modify_text_annotations().unwrap_or(false),
+        can_fill_forms: perms.can_fill_existing_interactive_form_fields().unwrap_or(false),
+        can_assemble:  perms.can_assemble_document().unwrap_or(false),
+    };
+
     Ok(DocumentInfo {
         title:             meta.get(Title).map(|t| t.value().to_string()),
         author:            meta.get(Author).map(|t| t.value().to_string()),
@@ -216,6 +259,7 @@ fn get_document_info(doc_id: u32, state: State<AppState>) -> Result<DocumentInfo
         page_count:        entry.page_count,
         file_size_bytes,
         pdf_version,
+        security,
     })
 }
 
@@ -641,6 +685,35 @@ mod tests {
         let state = empty_state();
         assert_eq!(require_doc(4, &state).err().unwrap(), "document 4 not found");
         assert_eq!(require_doc(5, &state).err().unwrap(), "document 5 not found");
+    }
+
+    #[test]
+    fn document_security_struct_fields_are_correct() {
+        let sec = DocumentSecurity {
+            is_protected: true,
+            revision: Some(3),
+            can_print: "high_quality".to_string(),
+            can_modify: false,
+            can_copy: true,
+            can_annotate: false,
+            can_fill_forms: true,
+            can_assemble: false,
+        };
+        assert!(sec.is_protected);
+        assert_eq!(sec.revision, Some(3));
+        assert_eq!(sec.can_print, "high_quality");
+        assert!(!sec.can_modify);
+        assert!(sec.can_copy);
+
+        let unprotected = DocumentSecurity {
+            is_protected: false,
+            revision: None,
+            can_print: "high_quality".to_string(),
+            can_modify: true, can_copy: true,
+            can_annotate: true, can_fill_forms: true, can_assemble: true,
+        };
+        assert!(!unprotected.is_protected);
+        assert_eq!(unprotected.revision, None);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -197,6 +197,14 @@ fn open_document(path: String, state: State<AppState>) -> Result<DocumentManifes
     })
 }
 
+/// Map the two pdfium print-quality booleans to the canonical string used in
+/// [`DocumentSecurity::can_print`].
+fn print_permission_label(hq: bool, lq: bool) -> &'static str {
+    if hq      { "high_quality" }
+    else if lq { "low_quality"  }
+    else       { "not_allowed"  }
+}
+
 /// Return metadata and file statistics for an open document.
 /// Fields sourced from the PDF InfoDict are Option — most real-world PDFs omit many of them.
 #[tauri::command]
@@ -232,22 +240,33 @@ fn get_document_info(doc_id: u32, state: State<AppState>) -> Result<DocumentInfo
         _             => None,
     };
     let is_protected = revision.is_some();
-    let can_print = if perms.can_print_high_quality().unwrap_or(false) {
-        "high_quality"
-    } else if perms.can_print_only_low_quality().unwrap_or(false) {
-        "low_quality"
-    } else {
-        "not_allowed"
-    }.to_string();
+    // NOTE: pdfium-render only exposes Revision2/3/4. A document whose
+    // security handler uses any other revision matches the `_` arm above
+    // (maps to None), so `is_protected` will be false for those documents.
+    // This is a known pdfium-render limitation; treat them as unprotected
+    // until the library exposes the extra variants.
+
+    // For unencrypted documents every permission is implicitly allowed.
+    // `default_perm` ensures a pdfium error on an unencrypted doc's
+    // permission call is reported as "allowed" rather than the
+    // security-conservative "denied".
+    let default_perm = !is_protected;
+    let can_print = {
+        let hq = perms.can_print_high_quality().unwrap_or(default_perm);
+        // low_quality is only true when the PDF explicitly restricts to it;
+        // never default to true (that would override the "high_quality" path).
+        let lq = perms.can_print_only_low_quality().unwrap_or(false);
+        print_permission_label(hq, lq).to_string()
+    };
     let security = DocumentSecurity {
         is_protected,
         revision,
         can_print,
-        can_modify:    perms.can_modify_document_content().unwrap_or(false),
-        can_copy:      perms.can_extract_text_and_graphics().unwrap_or(false),
-        can_annotate:  perms.can_add_or_modify_text_annotations().unwrap_or(false),
-        can_fill_forms: perms.can_fill_existing_interactive_form_fields().unwrap_or(false),
-        can_assemble:  perms.can_assemble_document().unwrap_or(false),
+        can_modify:    perms.can_modify_document_content().unwrap_or(default_perm),
+        can_copy:      perms.can_extract_text_and_graphics().unwrap_or(default_perm),
+        can_annotate:  perms.can_add_or_modify_text_annotations().unwrap_or(default_perm),
+        can_fill_forms: perms.can_fill_existing_interactive_form_fields().unwrap_or(default_perm),
+        can_assemble:  perms.can_assemble_document().unwrap_or(default_perm),
     };
 
     let page_size = doc.pages().get(0).ok().map(|p| PageSize {
@@ -697,72 +716,17 @@ mod tests {
     }
 
     #[test]
-    fn document_info_includes_page_size_field() {
-        // Verify that DocumentInfo carries a page_size field. The None path
-        // represents an empty document; the Some path is covered by integration
-        // tests that run against a real pdfium document.
-        let info_no_pages = DocumentInfo {
-            title: None, author: None, subject: None, keywords: None,
-            creator: None, producer: None,
-            creation_date: None, modification_date: None,
-            page_count: 0,
-            file_size_bytes: None,
-            pdf_version: None,
-            page_size: None,
-            security: DocumentSecurity {
-                is_protected: false, revision: None,
-                can_print: "high_quality".to_string(),
-                can_modify: true, can_copy: true,
-                can_annotate: true, can_fill_forms: true, can_assemble: true,
-            },
-        };
-        assert!(info_no_pages.page_size.is_none());
-
-        let info_with_page = DocumentInfo {
-            page_count: 1,
-            page_size: Some(PageSize { width_pts: 612.0, height_pts: 792.0 }),
-            ..info_no_pages
-        };
-        let ps = info_with_page.page_size.unwrap();
-        assert_eq!(ps.width_pts, 612.0);
-        assert_eq!(ps.height_pts, 792.0);
+    fn print_permission_label_high_quality() {
+        assert_eq!(print_permission_label(true, false), "high_quality");
     }
 
     #[test]
-    fn document_security_struct_fields_are_correct() {
-        let sec = DocumentSecurity {
-            is_protected: true,
-            revision: Some(3),
-            can_print: "high_quality".to_string(),
-            can_modify: false,
-            can_copy: true,
-            can_annotate: false,
-            can_fill_forms: true,
-            can_assemble: false,
-        };
-        assert!(sec.is_protected);
-        assert_eq!(sec.revision, Some(3));
-        assert_eq!(sec.can_print, "high_quality");
-        assert!(!sec.can_modify);
-        assert!(sec.can_copy);
-
-        let unprotected = DocumentSecurity {
-            is_protected: false,
-            revision: None,
-            can_print: "high_quality".to_string(),
-            can_modify: true, can_copy: true,
-            can_annotate: true, can_fill_forms: true, can_assemble: true,
-        };
-        assert!(!unprotected.is_protected);
-        assert_eq!(unprotected.revision, None);
+    fn print_permission_label_low_quality_when_hq_false() {
+        assert_eq!(print_permission_label(false, true), "low_quality");
     }
 
     #[test]
-    fn require_doc_unknown_id_returns_err() {
-        let state = empty_state();
-        assert_eq!(
-            require_doc(99, &state).err().unwrap(),
-            "document 99 not found"
-        );
+    fn print_permission_label_not_allowed_when_both_false() {
+        assert_eq!(print_permission_label(false, false), "not_allowed");
     }
 }

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -25,6 +25,7 @@ use tauri::{
 ///   "display-continuous" — View → Page Display → Continuous Scroll
 ///   "display-single"     — View → Page Display → Single Page
 ///   "display-spread"     — View → Page Display → Two-Page Spread
+///   "doc-info"           — View → Document Info
 ///   "zoom-in"            — View → Zoom In
 ///   "zoom-out"           — View → Zoom Out
 ///   "zoom-fit-width"     — View → Fit Width
@@ -100,6 +101,10 @@ pub fn build_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
     let display_menu       = Submenu::with_items(app, "Page Display", true, &[&display_continuous, &display_single, &display_spread])?;
     let sep_display        = PredefinedMenuItem::separator(app)?;
 
+    // ── View → Document Info ───────────────────────────────────────────────
+    let doc_info   = MenuItem::with_id(app, "doc-info", "Document Info", false, Some("CmdOrCtrl+I"))?;
+    let sep_info   = PredefinedMenuItem::separator(app)?;
+
     // ── View → Zoom ────────────────────────────────────────────────────────
     let zoom_in   = MenuItem::with_id(app, "zoom-in",       "Zoom In",   false, Some("CmdOrCtrl+="))?;
     let zoom_out  = MenuItem::with_id(app, "zoom-out",      "Zoom Out",  false, Some("CmdOrCtrl+-"))?;
@@ -116,7 +121,7 @@ pub fn build_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
         app,
         "View",
         true,
-        &[&display_menu, &sep_display, &zoom_menu, &sep_zoom, &appearance],
+        &[&display_menu, &sep_display, &doc_info, &sep_info, &zoom_menu, &sep_zoom, &appearance],
     )?;
 
     // ── Help (required by macOS HIG) ───────────────────────────────────────

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { listen } from "@tauri-apps/api/event";
 import { toast } from "sonner";
 import { BugIcon } from "lucide-react";
 import { BugReportDialog } from "./components/BugReportDialog";
+import { InfoPanel } from "./components/InfoPanel";
 import { ShortcutOverlay } from "./components/ShortcutOverlay";
 import { EmptyState } from "./components/EmptyState";
 import { PageViewer, PageViewerHandle } from "./components/PageViewer";
@@ -51,6 +52,9 @@ function App() {
   const theme = useAppStore((s) => s.theme);
   const setTheme = useAppStore((s) => s.setTheme);
   const isDirty = useAppStore((s) => s.isDirty);
+  const infoPanelOpen = useAppStore((s) => s.infoPanelOpen);
+  const setInfoPanelOpen = useAppStore((s) => s.setInfoPanelOpen);
+  const toggleInfoPanel = useAppStore((s) => s.toggleInfoPanel);
 
   // Apply theme (dark class on <html>) and keep it in sync with OS changes
   useTheme();
@@ -74,6 +78,7 @@ function App() {
     useAppStore.getState().setActivePage(0);
     useAppStore.getState().clearSelection();
     useAppStore.getState().setIsDirty(false);
+    useAppStore.getState().setInfoPanelOpen(false);
   }
 
   function showError(message: string) {
@@ -306,6 +311,8 @@ function App() {
           onSave={handleSave}
           onUndo={handleUndo}
           onRedo={handleRedo}
+          infoPanelOpen={infoPanelOpen}
+          onToggleInfo={toggleInfoPanel}
         />
 
         <Separator />
@@ -324,6 +331,14 @@ function App() {
 
         <StatusBar pageCount={manifest?.page_count} />
       </SidebarInset>
+
+      {manifest && (
+        <InfoPanel
+          docId={manifest.doc_id}
+          open={infoPanelOpen}
+          onOpenChange={setInfoPanelOpen}
+        />
+      )}
 
       <ShortcutOverlay open={showShortcuts} onClose={() => setShowShortcuts(false)} />
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -238,6 +238,7 @@ function App() {
     const unlistenDisplay = listen<string>("menu-display", (e) => {
       useAppStore.getState().setPageDisplay(e.payload as PageDisplay);
     });
+    const unlistenDocInfo   = listen<void>("menu-doc-info",   () => useAppStore.getState().toggleInfoPanel());
     const unlistenReportBug = listen<void>("menu-report-bug", () => {
       setBugReportOpen(true);
     });
@@ -267,6 +268,7 @@ function App() {
       unlistenMerge.then((fn) => fn());
       unlistenImport.then((fn) => fn());
       unlistenDisplay.then((fn) => fn());
+      unlistenDocInfo.then((fn) => fn());
       unlistenReportBug.then((fn) => fn());
       unlistenSave.then((fn) => fn());
       unlistenSaveAs.then((fn) => fn());

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -337,6 +337,7 @@ function App() {
       {manifest && (
         <InfoPanel
           docId={manifest.doc_id}
+          filename={manifest.filename}
           open={infoPanelOpen}
           onOpenChange={setInfoPanelOpen}
         />

--- a/src/components/InfoPanel.test.tsx
+++ b/src/components/InfoPanel.test.tsx
@@ -178,7 +178,7 @@ describe("InfoPanel — Security tab", () => {
     expect(await screen.findByText("None")).toBeInTheDocument();
   });
 
-  it("shows Permissions section only when protected", async () => {
+  it("shows Permissions section for a protected doc", async () => {
     renderPanel();
     await openSecurityTab();
     expect(await screen.findByText("Permissions")).toBeInTheDocument();

--- a/src/components/InfoPanel.test.tsx
+++ b/src/components/InfoPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { invoke } from "@tauri-apps/api/core";
@@ -20,6 +20,7 @@ const FULL_INFO = {
   page_count: 12,
   file_size_bytes: 393216,
   pdf_version: "PDF 1.7",
+  page_size: { width_pts: 612, height_pts: 792 },
   security: {
     is_protected: true,
     revision: 3,
@@ -44,6 +45,7 @@ const NULL_INFO = {
   page_count: 5,
   file_size_bytes: null,
   pdf_version: null,
+  page_size: null,
   security: {
     is_protected: false,
     revision: null,
@@ -56,9 +58,11 @@ const NULL_INFO = {
   },
 };
 
+const TEST_FILENAME = "contract.pdf";
+
 function renderPanel(overrides: Partial<typeof FULL_INFO> = {}, open = true) {
   vi.mocked(invoke).mockResolvedValue({ ...FULL_INFO, ...overrides });
-  return render(<InfoPanel docId={1} open={open} onOpenChange={vi.fn()} />);
+  return render(<InfoPanel docId={1} filename={TEST_FILENAME} open={open} onOpenChange={vi.fn()} />);
 }
 
 beforeEach(() => {
@@ -68,18 +72,40 @@ beforeEach(() => {
 describe("InfoPanel — loading state", () => {
   it("renders skeleton elements while invoke is pending", () => {
     vi.mocked(invoke).mockReturnValue(new Promise(() => {})); // never resolves
-    render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
+    render(<InfoPanel docId={1} filename={TEST_FILENAME} open={true} onOpenChange={vi.fn()} />);
     expect(document.querySelectorAll("[data-slot=skeleton]").length).toBeGreaterThan(0);
   });
 
   it("does not call invoke when open is false", () => {
     vi.mocked(invoke).mockResolvedValue(FULL_INFO);
-    render(<InfoPanel docId={1} open={false} onOpenChange={vi.fn()} />);
+    render(<InfoPanel docId={1} filename={TEST_FILENAME} open={false} onOpenChange={vi.fn()} />);
     expect(vi.mocked(invoke)).not.toHaveBeenCalled();
   });
 });
 
 describe("InfoPanel — Info tab", () => {
+  it("shows filename in Document section", async () => {
+    renderPanel();
+    expect(await screen.findByText("contract.pdf")).toBeInTheDocument();
+  });
+
+  it("shows 'PDF Document' as document type", async () => {
+    renderPanel();
+    expect(await screen.findByText("PDF Document")).toBeInTheDocument();
+  });
+
+  it("shows formatted page size in inches", async () => {
+    renderPanel();
+    expect(await screen.findByText("8.5 × 11 in")).toBeInTheDocument();
+  });
+
+  it("shows 'Not set' for page size when page_size is null", async () => {
+    vi.mocked(invoke).mockResolvedValue(NULL_INFO);
+    render(<InfoPanel docId={1} filename={TEST_FILENAME} open={true} onOpenChange={vi.fn()} />);
+    const notSetLabels = await screen.findAllByText("Not set");
+    expect(notSetLabels.length).toBeGreaterThan(0);
+  });
+
   it("shows page count", async () => {
     renderPanel();
     expect(await screen.findByText("12")).toBeInTheDocument();
@@ -97,7 +123,7 @@ describe("InfoPanel — Info tab", () => {
 
   it("shows 'Not set' for null title", async () => {
     vi.mocked(invoke).mockResolvedValue(NULL_INFO);
-    render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
+    render(<InfoPanel docId={1} filename={TEST_FILENAME} open={true} onOpenChange={vi.fn()} />);
     const notSetLabels = await screen.findAllByText("Not set");
     expect(notSetLabels.length).toBeGreaterThan(0);
   });
@@ -111,7 +137,7 @@ describe("InfoPanel — Info tab", () => {
 
   it("shows 'Not set' for null creation_date", async () => {
     vi.mocked(invoke).mockResolvedValue(NULL_INFO);
-    render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
+    render(<InfoPanel docId={1} filename={TEST_FILENAME} open={true} onOpenChange={vi.fn()} />);
     const notSetLabels = await screen.findAllByText("Not set");
     expect(notSetLabels.length).toBeGreaterThan(0);
   });
@@ -128,7 +154,7 @@ describe("InfoPanel — Keywords tab", () => {
 
   it("shows 'No keywords defined.' when keywords is null", async () => {
     vi.mocked(invoke).mockResolvedValue(NULL_INFO);
-    render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
+    render(<InfoPanel docId={1} filename={TEST_FILENAME} open={true} onOpenChange={vi.fn()} />);
     await userEvent.click(await screen.findByRole("tab", { name: /keywords/i }));
     expect(await screen.findByText(/no keywords defined/i)).toBeInTheDocument();
   });
@@ -147,7 +173,7 @@ describe("InfoPanel — Security tab", () => {
 
   it("shows 'None' for an unprotected doc", async () => {
     vi.mocked(invoke).mockResolvedValue(NULL_INFO);
-    render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
+    render(<InfoPanel docId={1} filename={TEST_FILENAME} open={true} onOpenChange={vi.fn()} />);
     await openSecurityTab();
     expect(await screen.findByText("None")).toBeInTheDocument();
   });
@@ -160,7 +186,7 @@ describe("InfoPanel — Security tab", () => {
 
   it("shows Permissions section for unprotected doc", async () => {
     vi.mocked(invoke).mockResolvedValue(NULL_INFO);
-    render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
+    render(<InfoPanel docId={1} filename={TEST_FILENAME} open={true} onOpenChange={vi.fn()} />);
     await openSecurityTab();
     expect(await screen.findByText("Permissions")).toBeInTheDocument();
   });
@@ -184,16 +210,94 @@ describe("InfoPanel — Security tab", () => {
   });
 });
 
+describe("InfoPanel — context menu copy", () => {
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("shows Copy Value and Copy label items when right-clicking a populated row", async () => {
+    renderPanel();
+    const dt = await screen.findByText("Author");
+    fireEvent.contextMenu(dt.closest("dl")!);
+    expect(await screen.findByText("Copy Value")).toBeInTheDocument();
+    expect(await screen.findByText(/Copy "Author:/)).toBeInTheDocument();
+  });
+
+  it("copies the value when Copy Value is clicked", async () => {
+    renderPanel();
+    const dt = await screen.findByText("Author");
+    fireEvent.contextMenu(dt.closest("dl")!);
+    await userEvent.click(await screen.findByText("Copy Value"));
+    expect(writeText).toHaveBeenCalledWith("Jane Smith");
+  });
+
+  it("copies label and value when the label copy item is clicked", async () => {
+    renderPanel();
+    const dt = await screen.findByText("Author");
+    fireEvent.contextMenu(dt.closest("dl")!);
+    await userEvent.click(await screen.findByText(/Copy "Author:/));
+    expect(writeText).toHaveBeenCalledWith("Author: Jane Smith");
+  });
+
+  it("disables copy items for null-value rows", async () => {
+    vi.mocked(invoke).mockResolvedValue(NULL_INFO);
+    render(<InfoPanel docId={1} filename={TEST_FILENAME} open={true} onOpenChange={vi.fn()} />);
+    const dt = await screen.findByText("Title");
+    fireEvent.contextMenu(dt.closest("dl")!);
+    const copyValueItem = await screen.findByRole("menuitem", { name: "Copy Value" });
+    expect(copyValueItem).toHaveAttribute("data-disabled");
+  });
+
+  it("shows Copy Keyword when right-clicking a keyword badge", async () => {
+    renderPanel({ keywords: "contract, legal" });
+    await userEvent.click(await screen.findByRole("tab", { name: /keywords/i }));
+    const badge = await screen.findByText("contract");
+    fireEvent.contextMenu(badge);
+    expect(await screen.findByText("Copy Keyword")).toBeInTheDocument();
+  });
+
+  it("copies the keyword when Copy Keyword is clicked", async () => {
+    renderPanel({ keywords: "contract, legal" });
+    await userEvent.click(await screen.findByRole("tab", { name: /keywords/i }));
+    const badge = await screen.findByText("contract");
+    fireEvent.contextMenu(badge);
+    await userEvent.click(await screen.findByText("Copy Keyword"));
+    expect(writeText).toHaveBeenCalledWith("contract");
+  });
+
+  it("shows Copy All Keywords when right-clicking the keywords area", async () => {
+    renderPanel({ keywords: "contract, legal" });
+    await userEvent.click(await screen.findByRole("tab", { name: /keywords/i }));
+    fireEvent.contextMenu(screen.getByTestId("keywords-area"));
+    expect(await screen.findByText("Copy All Keywords")).toBeInTheDocument();
+  });
+
+  it("copies all keywords when Copy All Keywords is clicked", async () => {
+    renderPanel({ keywords: "contract, legal" });
+    await userEvent.click(await screen.findByRole("tab", { name: /keywords/i }));
+    fireEvent.contextMenu(screen.getByTestId("keywords-area"));
+    await userEvent.click(await screen.findByText("Copy All Keywords"));
+    expect(writeText).toHaveBeenCalledWith("contract, legal");
+  });
+});
+
 describe("InfoPanel — error state", () => {
   it("renders the sheet header even if invoke rejects", async () => {
     vi.mocked(invoke).mockRejectedValue(new Error("not found"));
-    render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
+    render(<InfoPanel docId={1} filename={TEST_FILENAME} open={true} onOpenChange={vi.fn()} />);
     expect(await screen.findByText(/document info/i)).toBeInTheDocument();
   });
 
   it("shows error message in Info tab when invoke rejects", async () => {
     vi.mocked(invoke).mockRejectedValue(new Error("not found"));
-    render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
+    render(<InfoPanel docId={1} filename={TEST_FILENAME} open={true} onOpenChange={vi.fn()} />);
     expect(await screen.findByText(/could not load document info/i)).toBeInTheDocument();
   });
 });

--- a/src/components/InfoPanel.test.tsx
+++ b/src/components/InfoPanel.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { InfoPanel } from "./InfoPanel";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+const FULL_INFO = {
+  title: "My Contract",
+  author: "Jane Smith",
+  subject: "Legal",
+  keywords: "contract, legal, 2023",
+  creator: "Word",
+  producer: "Adobe PDF",
+  creation_date: "D:20230415143022",
+  modification_date: null,
+  page_count: 12,
+  file_size_bytes: 393216,
+  pdf_version: "PDF 1.7",
+};
+
+const NULL_INFO = {
+  title: null,
+  author: null,
+  subject: null,
+  keywords: null,
+  creator: null,
+  producer: null,
+  creation_date: null,
+  modification_date: null,
+  page_count: 5,
+  file_size_bytes: null,
+  pdf_version: null,
+};
+
+function renderPanel(overrides: Partial<typeof FULL_INFO> = {}, open = true) {
+  vi.mocked(invoke).mockResolvedValue({ ...FULL_INFO, ...overrides });
+  return render(<InfoPanel docId={1} open={open} onOpenChange={vi.fn()} />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("InfoPanel — loading state", () => {
+  it("renders skeleton elements while invoke is pending", () => {
+    vi.mocked(invoke).mockReturnValue(new Promise(() => {})); // never resolves
+    render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
+    expect(document.querySelectorAll("[data-slot=skeleton]").length).toBeGreaterThan(0);
+  });
+});
+
+describe("InfoPanel — Info tab", () => {
+  it("shows page count", async () => {
+    renderPanel();
+    expect(await screen.findByText("12")).toBeInTheDocument();
+  });
+
+  it("shows formatted file size", async () => {
+    renderPanel();
+    expect(await screen.findByText("384.0 KB")).toBeInTheDocument();
+  });
+
+  it("shows pdf version", async () => {
+    renderPanel();
+    expect(await screen.findByText("PDF 1.7")).toBeInTheDocument();
+  });
+
+  it("shows 'Not set' for null title", async () => {
+    vi.mocked(invoke).mockResolvedValue(NULL_INFO);
+    render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
+    const notSetLabels = await screen.findAllByText("Not set");
+    expect(notSetLabels.length).toBeGreaterThan(0);
+  });
+
+  it("shows formatted date for valid creation_date", async () => {
+    renderPanel();
+    // parsePdfDate extracts the year at minimum
+    const el = await screen.findByText(/2023/);
+    expect(el).toBeInTheDocument();
+  });
+
+  it("shows 'Not set' for null creation_date", async () => {
+    vi.mocked(invoke).mockResolvedValue(NULL_INFO);
+    render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
+    const notSetLabels = await screen.findAllByText("Not set");
+    expect(notSetLabels.length).toBeGreaterThan(0);
+  });
+});
+
+describe("InfoPanel — Keywords tab", () => {
+  it("shows keyword badges for comma-separated keywords", async () => {
+    renderPanel({ keywords: "contract, legal, 2023" });
+    await userEvent.click(await screen.findByRole("tab", { name: /keywords/i }));
+    expect(await screen.findByText("contract")).toBeInTheDocument();
+    expect(await screen.findByText("legal")).toBeInTheDocument();
+    expect(await screen.findByText("2023")).toBeInTheDocument();
+  });
+
+  it("shows 'No keywords defined.' when keywords is null", async () => {
+    vi.mocked(invoke).mockResolvedValue(NULL_INFO);
+    render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
+    await userEvent.click(await screen.findByRole("tab", { name: /keywords/i }));
+    expect(await screen.findByText(/no keywords defined/i)).toBeInTheDocument();
+  });
+});
+
+describe("InfoPanel — error state", () => {
+  it("renders the sheet header even if invoke rejects", async () => {
+    vi.mocked(invoke).mockRejectedValue(new Error("not found"));
+    render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
+    expect(await screen.findByText(/document info/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/InfoPanel.test.tsx
+++ b/src/components/InfoPanel.test.tsx
@@ -20,6 +20,16 @@ const FULL_INFO = {
   page_count: 12,
   file_size_bytes: 393216,
   pdf_version: "PDF 1.7",
+  security: {
+    is_protected: true,
+    revision: 3,
+    can_print: "high_quality",
+    can_modify: false,
+    can_copy: true,
+    can_annotate: false,
+    can_fill_forms: true,
+    can_assemble: false,
+  },
 };
 
 const NULL_INFO = {
@@ -34,6 +44,16 @@ const NULL_INFO = {
   page_count: 5,
   file_size_bytes: null,
   pdf_version: null,
+  security: {
+    is_protected: false,
+    revision: null,
+    can_print: "high_quality",
+    can_modify: true,
+    can_copy: true,
+    can_annotate: true,
+    can_fill_forms: true,
+    can_assemble: true,
+  },
 };
 
 function renderPanel(overrides: Partial<typeof FULL_INFO> = {}, open = true) {
@@ -111,6 +131,56 @@ describe("InfoPanel — Keywords tab", () => {
     render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
     await userEvent.click(await screen.findByRole("tab", { name: /keywords/i }));
     expect(await screen.findByText(/no keywords defined/i)).toBeInTheDocument();
+  });
+});
+
+describe("InfoPanel — Security tab", () => {
+  async function openSecurityTab() {
+    await userEvent.click(await screen.findByRole("tab", { name: /security/i }));
+  }
+
+  it("shows 'Encrypted (Rev. 3)' for a protected doc", async () => {
+    renderPanel();
+    await openSecurityTab();
+    expect(await screen.findByText("Encrypted (Rev. 3)")).toBeInTheDocument();
+  });
+
+  it("shows 'None' for an unprotected doc", async () => {
+    vi.mocked(invoke).mockResolvedValue(NULL_INFO);
+    render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
+    await openSecurityTab();
+    expect(await screen.findByText("None")).toBeInTheDocument();
+  });
+
+  it("shows Permissions section only when protected", async () => {
+    renderPanel();
+    await openSecurityTab();
+    expect(await screen.findByText("Permissions")).toBeInTheDocument();
+  });
+
+  it("shows Permissions section for unprotected doc", async () => {
+    vi.mocked(invoke).mockResolvedValue(NULL_INFO);
+    render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
+    await openSecurityTab();
+    expect(await screen.findByText("Permissions")).toBeInTheDocument();
+  });
+
+  it("shows 'Allowed' for a permitted action", async () => {
+    renderPanel(); // can_copy: true
+    await openSecurityTab();
+    expect(await screen.findAllByText("Allowed")).not.toHaveLength(0);
+  });
+
+  it("shows 'Not allowed' for a denied action", async () => {
+    renderPanel(); // can_modify: false
+    await openSecurityTab();
+    expect(await screen.findAllByText("Not allowed")).not.toHaveLength(0);
+  });
+
+  it("shows 'Low quality only' for low-quality print permission", async () => {
+    renderPanel({ security: { ...FULL_INFO.security, can_print: "low_quality" } });
+    await openSecurityTab();
+    expect(await screen.findByText("Low quality only")).toBeInTheDocument();
   });
 });
 

--- a/src/components/InfoPanel.test.tsx
+++ b/src/components/InfoPanel.test.tsx
@@ -51,6 +51,12 @@ describe("InfoPanel — loading state", () => {
     render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
     expect(document.querySelectorAll("[data-slot=skeleton]").length).toBeGreaterThan(0);
   });
+
+  it("does not call invoke when open is false", () => {
+    vi.mocked(invoke).mockResolvedValue(FULL_INFO);
+    render(<InfoPanel docId={1} open={false} onOpenChange={vi.fn()} />);
+    expect(vi.mocked(invoke)).not.toHaveBeenCalled();
+  });
 });
 
 describe("InfoPanel — Info tab", () => {
@@ -113,5 +119,11 @@ describe("InfoPanel — error state", () => {
     vi.mocked(invoke).mockRejectedValue(new Error("not found"));
     render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
     expect(await screen.findByText(/document info/i)).toBeInTheDocument();
+  });
+
+  it("shows error message in Info tab when invoke rejects", async () => {
+    vi.mocked(invoke).mockRejectedValue(new Error("not found"));
+    render(<InfoPanel docId={1} open={true} onOpenChange={vi.fn()} />);
+    expect(await screen.findByText(/could not load document info/i)).toBeInTheDocument();
   });
 });

--- a/src/components/InfoPanel.tsx
+++ b/src/components/InfoPanel.tsx
@@ -19,6 +19,17 @@ import {
 import { parsePdfDate, formatBytes } from "@/lib/pdfDate";
 
 
+interface DocumentSecurity {
+  is_protected:  boolean;
+  revision:      number | null;
+  can_print:     "high_quality" | "low_quality" | "not_allowed";
+  can_modify:    boolean;
+  can_copy:      boolean;
+  can_annotate:  boolean;
+  can_fill_forms: boolean;
+  can_assemble:  boolean;
+}
+
 interface DocumentInfo {
   title:             string | null;
   author:            string | null;
@@ -31,6 +42,7 @@ interface DocumentInfo {
   page_count:        number;
   file_size_bytes:   number | null;
   pdf_version:       string | null;
+  security:          DocumentSecurity;
 }
 
 interface InfoPanelProps {
@@ -65,6 +77,38 @@ function RowList({ rows }: { rows: Array<{ label: string; value: string | null }
   );
 }
 
+
+function SecurityContent({ security }: { security: DocumentSecurity }) {
+  const encryptionStatus = security.is_protected
+    ? `Encrypted (Rev. ${security.revision})`
+    : "None";
+
+  const printLabel =
+    security.can_print === "high_quality" ? "Allowed"
+    : security.can_print === "low_quality" ? "Low quality only"
+    : "Not allowed";
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="bg-muted/30 rounded-lg p-3">
+        <p className="text-xs font-medium text-muted-foreground mb-2">Encryption</p>
+        <RowList rows={[{ label: "Protection", value: encryptionStatus }]} />
+      </div>
+
+      <div className="bg-muted/30 rounded-lg p-3">
+        <p className="text-xs font-medium text-muted-foreground mb-2">Permissions</p>
+        <RowList rows={[
+          { label: "Printing",    value: printLabel },
+          { label: "Modify",      value: security.can_modify     ? "Allowed" : "Not allowed" },
+          { label: "Copy text",   value: security.can_copy       ? "Allowed" : "Not allowed" },
+          { label: "Annotations", value: security.can_annotate   ? "Allowed" : "Not allowed" },
+          { label: "Fill forms",  value: security.can_fill_forms ? "Allowed" : "Not allowed" },
+          { label: "Assemble",    value: security.can_assemble   ? "Allowed" : "Not allowed" },
+        ]} />
+      </div>
+    </div>
+  );
+}
 
 function LoadingSkeleton() {
   return (
@@ -114,6 +158,7 @@ export function InfoPanel({ docId, open, onOpenChange }: InfoPanelProps) {
           <TabsList className="mx-4 mt-3 shrink-0 justify-start w-auto">
             <TabsTrigger value="info">Info</TabsTrigger>
             <TabsTrigger value="keywords">Keywords</TabsTrigger>
+            <TabsTrigger value="security">Security</TabsTrigger>
           </TabsList>
 
           <TabsContent value="info" className="flex-1 overflow-y-auto px-4 py-3 mt-0">
@@ -169,6 +214,16 @@ export function InfoPanel({ docId, open, onOpenChange }: InfoPanelProps) {
               <p className="text-sm text-muted-foreground text-center mt-8">
                 No keywords defined.
               </p>
+            )}
+          </TabsContent>
+
+          <TabsContent value="security" className="flex-1 overflow-y-auto px-4 py-3 mt-0">
+            {loading ? (
+              <LoadingSkeleton />
+            ) : error ? (
+              <p className="text-sm text-destructive text-center mt-8">Could not load document info.</p>
+            ) : (
+              <SecurityContent security={info!.security} />
             )}
           </TabsContent>
 

--- a/src/components/InfoPanel.tsx
+++ b/src/components/InfoPanel.tsx
@@ -277,8 +277,10 @@ export function InfoPanel({ docId, filename, open, onOpenChange }: InfoPanelProp
               <LoadingSkeleton />
             ) : error ? (
               <p className="text-sm text-destructive text-center mt-8">Could not load document info.</p>
+            ) : info == null ? (
+              <LoadingSkeleton />
             ) : (
-              <SecurityContent security={info!.security} />
+              <SecurityContent security={info.security} />
             )}
           </TabsContent>
 

--- a/src/components/InfoPanel.tsx
+++ b/src/components/InfoPanel.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+import { parsePdfDate, formatBytes } from "@/lib/pdfDate";
+
+interface DocumentInfo {
+  title:             string | null;
+  author:            string | null;
+  subject:           string | null;
+  keywords:          string | null;
+  creator:           string | null;
+  producer:          string | null;
+  creation_date:     string | null;
+  modification_date: string | null;
+  page_count:        number;
+  file_size_bytes:   number | null;
+  pdf_version:       string | null;
+}
+
+interface InfoPanelProps {
+  docId: number;
+  open: boolean;
+  onOpenChange(open: boolean): void;
+}
+
+/** A label/value row in a <dl> grid. Null values render "Not set" in muted text. */
+function Row({ label, value }: { label: string; value: string | null }) {
+  return (
+    <>
+      <dt className="text-xs text-muted-foreground">{label}</dt>
+      {value !== null ? (
+        <dd className="text-xs font-medium break-all">{value}</dd>
+      ) : (
+        <dd className="text-xs text-muted-foreground/60">Not set</dd>
+      )}
+    </>
+  );
+}
+
+/** A section label above a group of rows. */
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-xs uppercase tracking-wide text-muted-foreground mb-2">
+      {children}
+    </p>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div className="flex flex-col gap-4">
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="flex flex-col gap-2">
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-3 w-full" />
+          <Skeleton className="h-3 w-3/4" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function InfoPanel({ docId, open, onOpenChange }: InfoPanelProps) {
+  const [info, setInfo] = useState<DocumentInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    setInfo(null);
+    invoke<DocumentInfo>("get_document_info", { docId })
+      .then(setInfo)
+      .catch(() => setInfo(null))
+      .finally(() => setLoading(false));
+  }, [docId]);
+
+  const keywords = info?.keywords
+    ? info.keywords.split(/[,;]+/).map((k) => k.trim()).filter(Boolean)
+    : [];
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-80 flex flex-col gap-0 p-0">
+        <SheetHeader className="px-4 py-3 border-b shrink-0">
+          <SheetTitle className="text-sm">Document Info</SheetTitle>
+        </SheetHeader>
+
+        <Tabs defaultValue="info" className="flex flex-col flex-1 min-h-0">
+          <TabsList className="mx-4 mt-3 shrink-0 justify-start w-auto">
+            <TabsTrigger value="info">Info</TabsTrigger>
+            <TabsTrigger value="keywords">Keywords</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="info" className="flex-1 overflow-y-auto px-4 py-3 mt-0">
+            {loading ? (
+              <LoadingSkeleton />
+            ) : (
+              <div className="flex flex-col gap-0">
+                <SectionLabel>General</SectionLabel>
+                <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5">
+                  <Row label="Pages"   value={String(info?.page_count ?? "—")} />
+                  <Row label="Size"    value={formatBytes(info?.file_size_bytes ?? null)} />
+                  <Row label="Version" value={info?.pdf_version ?? null} />
+                </dl>
+
+                <Separator className="my-3" />
+
+                <SectionLabel>Metadata</SectionLabel>
+                <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5">
+                  <Row label="Title"    value={info?.title    ?? null} />
+                  <Row label="Author"   value={info?.author   ?? null} />
+                  <Row label="Subject"  value={info?.subject  ?? null} />
+                  <Row label="Creator"  value={info?.creator  ?? null} />
+                  <Row label="Producer" value={info?.producer ?? null} />
+                </dl>
+
+                <Separator className="my-3" />
+
+                <SectionLabel>Dates</SectionLabel>
+                <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5">
+                  <Row label="Created"  value={parsePdfDate(info?.creation_date     ?? null)} />
+                  <Row label="Modified" value={parsePdfDate(info?.modification_date ?? null)} />
+                </dl>
+              </div>
+            )}
+          </TabsContent>
+
+          <TabsContent value="keywords" className="flex-1 overflow-y-auto px-4 py-3 mt-0">
+            {loading ? (
+              <LoadingSkeleton />
+            ) : keywords.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {keywords.map((kw) => (
+                  <Badge key={kw} variant="secondary">{kw}</Badge>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground text-center mt-8">
+                No keywords defined.
+              </p>
+            )}
+          </TabsContent>
+        </Tabs>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/InfoPanel.tsx
+++ b/src/components/InfoPanel.tsx
@@ -17,6 +17,7 @@ import {
   TabsTrigger,
 } from "@/components/ui/tabs";
 import { parsePdfDate, formatBytes } from "@/lib/pdfDate";
+import { PanelSection } from "@/components/PanelSection";
 
 
 interface DocumentSecurity {
@@ -90,13 +91,11 @@ function SecurityContent({ security }: { security: DocumentSecurity }) {
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="bg-muted/30 rounded-lg p-3">
-        <p className="text-xs font-medium text-muted-foreground mb-2">Encryption</p>
+      <PanelSection heading="Encryption">
         <RowList rows={[{ label: "Protection", value: encryptionStatus }]} />
-      </div>
+      </PanelSection>
 
-      <div className="bg-muted/30 rounded-lg p-3">
-        <p className="text-xs font-medium text-muted-foreground mb-2">Permissions</p>
+      <PanelSection heading="Permissions">
         <RowList rows={[
           { label: "Printing",    value: printLabel },
           { label: "Modify",      value: security.can_modify     ? "Allowed" : "Not allowed" },
@@ -105,7 +104,7 @@ function SecurityContent({ security }: { security: DocumentSecurity }) {
           { label: "Fill forms",  value: security.can_fill_forms ? "Allowed" : "Not allowed" },
           { label: "Assemble",    value: security.can_assemble   ? "Allowed" : "Not allowed" },
         ]} />
-      </div>
+      </PanelSection>
     </div>
   );
 }
@@ -168,17 +167,15 @@ export function InfoPanel({ docId, open, onOpenChange }: InfoPanelProps) {
               <p className="text-sm text-destructive text-center mt-8">Could not load document info.</p>
             ) : (
               <div className="flex flex-col gap-3">
-                <div className="bg-muted/30 rounded-lg p-3">
-                  <p className="text-xs font-medium text-muted-foreground mb-2">General</p>
+                <PanelSection heading="General">
                   <RowList rows={[
                     { label: "Pages",   value: String(info?.page_count ?? "—") },
                     { label: "Size",    value: formatBytes(info?.file_size_bytes ?? null) },
                     { label: "Version", value: info?.pdf_version ?? null },
                   ]} />
-                </div>
+                </PanelSection>
 
-                <div className="bg-muted/30 rounded-lg p-3">
-                  <p className="text-xs font-medium text-muted-foreground mb-2">Metadata</p>
+                <PanelSection heading="Metadata">
                   <RowList rows={[
                     { label: "Title",    value: info?.title    ?? null },
                     { label: "Author",   value: info?.author   ?? null },
@@ -186,15 +183,14 @@ export function InfoPanel({ docId, open, onOpenChange }: InfoPanelProps) {
                     { label: "Creator",  value: info?.creator  ?? null },
                     { label: "Producer", value: info?.producer ?? null },
                   ]} />
-                </div>
+                </PanelSection>
 
-                <div className="bg-muted/30 rounded-lg p-3">
-                  <p className="text-xs font-medium text-muted-foreground mb-2">Dates</p>
+                <PanelSection heading="Dates">
                   <RowList rows={[
                     { label: "Created",  value: parsePdfDate(info?.creation_date     ?? null) },
                     { label: "Modified", value: parsePdfDate(info?.modification_date ?? null) },
                   ]} />
-                </div>
+                </PanelSection>
               </div>
             )}
           </TabsContent>

--- a/src/components/InfoPanel.tsx
+++ b/src/components/InfoPanel.tsx
@@ -41,12 +41,12 @@ interface InfoPanelProps {
 
 function Row({ label, value }: { label: string; value: string | null }) {
   return (
-    <dl className="flex items-center justify-between">
-      <dt>{label}</dt>
+    <dl className="flex items-start justify-between">
+      <dt className="shrink-0 pr-4">{label}</dt>
       {value !== null ? (
         <dd className="text-muted-foreground text-right break-all">{value}</dd>
       ) : (
-        <dd className="text-muted-foreground/60">Not set</dd>
+        <dd className="text-muted-foreground/60 shrink-0">Not set</dd>
       )}
     </dl>
   );
@@ -83,15 +83,18 @@ function LoadingSkeleton() {
 export function InfoPanel({ docId, open, onOpenChange }: InfoPanelProps) {
   const [info, setInfo] = useState<DocumentInfo | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
+    if (!open) return;
     setLoading(true);
     setInfo(null);
+    setError(false);
     invoke<DocumentInfo>("get_document_info", { docId })
       .then(setInfo)
-      .catch(() => setInfo(null))
+      .catch(() => setError(true))
       .finally(() => setLoading(false));
-  }, [docId]);
+  }, [docId, open]);
 
   const keywords = info?.keywords
     ? info.keywords.split(/[,;]+/).map((k) => k.trim()).filter(Boolean)
@@ -116,6 +119,8 @@ export function InfoPanel({ docId, open, onOpenChange }: InfoPanelProps) {
           <TabsContent value="info" className="flex-1 overflow-y-auto px-4 py-3 mt-0">
             {loading ? (
               <LoadingSkeleton />
+            ) : error ? (
+              <p className="text-sm text-destructive text-center mt-8">Could not load document info.</p>
             ) : (
               <div className="flex flex-col gap-3">
                 <div className="bg-muted/30 rounded-lg p-3">
@@ -152,6 +157,8 @@ export function InfoPanel({ docId, open, onOpenChange }: InfoPanelProps) {
           <TabsContent value="keywords" className="flex-1 overflow-y-auto px-4 py-3 mt-0">
             {loading ? (
               <LoadingSkeleton />
+            ) : error ? (
+              <p className="text-sm text-destructive text-center mt-8">Could not load document info.</p>
             ) : keywords.length > 0 ? (
               <div className="flex flex-wrap gap-2">
                 {keywords.map((kw) => (

--- a/src/components/InfoPanel.tsx
+++ b/src/components/InfoPanel.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, Fragment } from "react";
+import { Info } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { Badge } from "@/components/ui/badge";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   Sheet,
   SheetContent,
@@ -16,6 +17,7 @@ import {
   TabsTrigger,
 } from "@/components/ui/tabs";
 import { parsePdfDate, formatBytes } from "@/lib/pdfDate";
+
 
 interface DocumentInfo {
   title:             string | null;
@@ -37,28 +39,32 @@ interface InfoPanelProps {
   onOpenChange(open: boolean): void;
 }
 
-/** A label/value row in a <dl> grid. Null values render "Not set" in muted text. */
 function Row({ label, value }: { label: string; value: string | null }) {
   return (
-    <>
-      <dt className="text-xs text-muted-foreground">{label}</dt>
+    <dl className="flex items-center justify-between">
+      <dt>{label}</dt>
       {value !== null ? (
-        <dd className="text-xs font-medium break-all">{value}</dd>
+        <dd className="text-muted-foreground text-right break-all">{value}</dd>
       ) : (
-        <dd className="text-xs text-muted-foreground/60">Not set</dd>
+        <dd className="text-muted-foreground/60">Not set</dd>
       )}
-    </>
+    </dl>
   );
 }
 
-/** A section label above a group of rows. */
-function SectionLabel({ children }: { children: React.ReactNode }) {
+function RowList({ rows }: { rows: Array<{ label: string; value: string | null }> }) {
   return (
-    <p className="text-xs uppercase tracking-wide text-muted-foreground mb-2">
-      {children}
-    </p>
+    <div className="flex flex-col gap-2 text-xs">
+      {rows.map((row, i) => (
+        <Fragment key={row.label}>
+          {i > 0 && <Separator />}
+          <Row label={row.label} value={row.value} />
+        </Fragment>
+      ))}
+    </div>
   );
 }
+
 
 function LoadingSkeleton() {
   return (
@@ -94,8 +100,11 @@ export function InfoPanel({ docId, open, onOpenChange }: InfoPanelProps) {
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent side="right" className="w-80 flex flex-col gap-0 p-0">
-        <SheetHeader className="px-4 py-3 border-b shrink-0">
-          <SheetTitle className="text-sm">Document Info</SheetTitle>
+        <SheetHeader className="px-4 py-3 shrink-0">
+          <SheetTitle className="text-sm flex items-center gap-2">
+            <Info className="size-4 shrink-0" />
+            Document Info
+          </SheetTitle>
         </SheetHeader>
 
         <Tabs defaultValue="info" className="flex flex-col flex-1 min-h-0">
@@ -108,32 +117,34 @@ export function InfoPanel({ docId, open, onOpenChange }: InfoPanelProps) {
             {loading ? (
               <LoadingSkeleton />
             ) : (
-              <div className="flex flex-col gap-0">
-                <SectionLabel>General</SectionLabel>
-                <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5">
-                  <Row label="Pages"   value={String(info?.page_count ?? "—")} />
-                  <Row label="Size"    value={formatBytes(info?.file_size_bytes ?? null)} />
-                  <Row label="Version" value={info?.pdf_version ?? null} />
-                </dl>
+              <div className="flex flex-col gap-3">
+                <div className="bg-muted/30 rounded-lg p-3">
+                  <p className="text-xs font-medium text-muted-foreground mb-2">General</p>
+                  <RowList rows={[
+                    { label: "Pages",   value: String(info?.page_count ?? "—") },
+                    { label: "Size",    value: formatBytes(info?.file_size_bytes ?? null) },
+                    { label: "Version", value: info?.pdf_version ?? null },
+                  ]} />
+                </div>
 
-                <Separator className="my-3" />
+                <div className="bg-muted/30 rounded-lg p-3">
+                  <p className="text-xs font-medium text-muted-foreground mb-2">Metadata</p>
+                  <RowList rows={[
+                    { label: "Title",    value: info?.title    ?? null },
+                    { label: "Author",   value: info?.author   ?? null },
+                    { label: "Subject",  value: info?.subject  ?? null },
+                    { label: "Creator",  value: info?.creator  ?? null },
+                    { label: "Producer", value: info?.producer ?? null },
+                  ]} />
+                </div>
 
-                <SectionLabel>Metadata</SectionLabel>
-                <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5">
-                  <Row label="Title"    value={info?.title    ?? null} />
-                  <Row label="Author"   value={info?.author   ?? null} />
-                  <Row label="Subject"  value={info?.subject  ?? null} />
-                  <Row label="Creator"  value={info?.creator  ?? null} />
-                  <Row label="Producer" value={info?.producer ?? null} />
-                </dl>
-
-                <Separator className="my-3" />
-
-                <SectionLabel>Dates</SectionLabel>
-                <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5">
-                  <Row label="Created"  value={parsePdfDate(info?.creation_date     ?? null)} />
-                  <Row label="Modified" value={parsePdfDate(info?.modification_date ?? null)} />
-                </dl>
+                <div className="bg-muted/30 rounded-lg p-3">
+                  <p className="text-xs font-medium text-muted-foreground mb-2">Dates</p>
+                  <RowList rows={[
+                    { label: "Created",  value: parsePdfDate(info?.creation_date     ?? null) },
+                    { label: "Modified", value: parsePdfDate(info?.modification_date ?? null) },
+                  ]} />
+                </div>
               </div>
             )}
           </TabsContent>
@@ -153,6 +164,7 @@ export function InfoPanel({ docId, open, onOpenChange }: InfoPanelProps) {
               </p>
             )}
           </TabsContent>
+
         </Tabs>
       </SheetContent>
     </Sheet>

--- a/src/components/InfoPanel.tsx
+++ b/src/components/InfoPanel.tsx
@@ -18,6 +18,12 @@ import {
 } from "@/components/ui/tabs";
 import { parsePdfDate, formatBytes } from "@/lib/pdfDate";
 import { PanelSection } from "@/components/PanelSection";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 
 
 interface DocumentSecurity {
@@ -43,25 +49,45 @@ interface DocumentInfo {
   page_count:        number;
   file_size_bytes:   number | null;
   pdf_version:       string | null;
+  page_size:         { width_pts: number; height_pts: number } | null;
   security:          DocumentSecurity;
 }
 
 interface InfoPanelProps {
   docId: number;
+  filename: string;
   open: boolean;
   onOpenChange(open: boolean): void;
 }
 
 function Row({ label, value }: { label: string; value: string | null }) {
   return (
-    <dl className="flex items-start justify-between">
-      <dt className="shrink-0 pr-4">{label}</dt>
-      {value !== null ? (
-        <dd className="text-muted-foreground text-right break-all">{value}</dd>
-      ) : (
-        <dd className="text-muted-foreground/60 shrink-0">Not set</dd>
-      )}
-    </dl>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <dl className="flex items-start justify-between cursor-default select-none">
+          <dt className="shrink-0 pr-4">{label}</dt>
+          {value !== null ? (
+            <dd className="text-muted-foreground text-right break-all">{value}</dd>
+          ) : (
+            <dd className="text-muted-foreground/60 shrink-0">Not set</dd>
+          )}
+        </dl>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem
+          disabled={value === null}
+          onSelect={() => navigator.clipboard.writeText(value!)}
+        >
+          Copy Value
+        </ContextMenuItem>
+        <ContextMenuItem
+          disabled={value === null}
+          onSelect={() => navigator.clipboard.writeText(`${label}: ${value}`)}
+        >
+          {`Copy "${label}: …"`}
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }
 
@@ -109,6 +135,13 @@ function SecurityContent({ security }: { security: DocumentSecurity }) {
   );
 }
 
+function formatPageSize(ps: { width_pts: number; height_pts: number } | null): string | null {
+  if (!ps) return null;
+  const w = parseFloat((ps.width_pts  / 72).toFixed(2));
+  const h = parseFloat((ps.height_pts / 72).toFixed(2));
+  return `${w} × ${h} in`;
+}
+
 function LoadingSkeleton() {
   return (
     <div className="flex flex-col gap-4">
@@ -123,7 +156,7 @@ function LoadingSkeleton() {
   );
 }
 
-export function InfoPanel({ docId, open, onOpenChange }: InfoPanelProps) {
+export function InfoPanel({ docId, filename, open, onOpenChange }: InfoPanelProps) {
   const [info, setInfo] = useState<DocumentInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -167,11 +200,19 @@ export function InfoPanel({ docId, open, onOpenChange }: InfoPanelProps) {
               <p className="text-sm text-destructive text-center mt-8">Could not load document info.</p>
             ) : (
               <div className="flex flex-col gap-3">
+                <PanelSection heading="Document">
+                  <RowList rows={[
+                    { label: "Name", value: filename },
+                    { label: "Type", value: "PDF Document" },
+                  ]} />
+                </PanelSection>
+
                 <PanelSection heading="General">
                   <RowList rows={[
-                    { label: "Pages",   value: String(info?.page_count ?? "—") },
-                    { label: "Size",    value: formatBytes(info?.file_size_bytes ?? null) },
-                    { label: "Version", value: info?.pdf_version ?? null },
+                    { label: "Pages",     value: String(info?.page_count ?? "—") },
+                    { label: "Size",      value: formatBytes(info?.file_size_bytes ?? null) },
+                    { label: "Version",   value: info?.pdf_version ?? null },
+                    { label: "Page Size", value: formatPageSize(info?.page_size ?? null) },
                   ]} />
                 </PanelSection>
 
@@ -201,11 +242,29 @@ export function InfoPanel({ docId, open, onOpenChange }: InfoPanelProps) {
             ) : error ? (
               <p className="text-sm text-destructive text-center mt-8">Could not load document info.</p>
             ) : keywords.length > 0 ? (
-              <div className="flex flex-wrap gap-2">
-                {keywords.map((kw) => (
-                  <Badge key={kw} variant="secondary">{kw}</Badge>
-                ))}
-              </div>
+              <ContextMenu>
+                <ContextMenuTrigger asChild>
+                  <div className="flex flex-wrap gap-2" data-testid="keywords-area">
+                    {keywords.map((kw) => (
+                      <ContextMenu key={kw}>
+                        <ContextMenuTrigger asChild>
+                          <Badge variant="secondary" className="cursor-default">{kw}</Badge>
+                        </ContextMenuTrigger>
+                        <ContextMenuContent>
+                          <ContextMenuItem onSelect={() => navigator.clipboard.writeText(kw)}>
+                            Copy Keyword
+                          </ContextMenuItem>
+                        </ContextMenuContent>
+                      </ContextMenu>
+                    ))}
+                  </div>
+                </ContextMenuTrigger>
+                <ContextMenuContent>
+                  <ContextMenuItem onSelect={() => navigator.clipboard.writeText(keywords.join(", "))}>
+                    Copy All Keywords
+                  </ContextMenuItem>
+                </ContextMenuContent>
+              </ContextMenu>
             ) : (
               <p className="text-sm text-muted-foreground text-center mt-8">
                 No keywords defined.

--- a/src/components/PanelSection.tsx
+++ b/src/components/PanelSection.tsx
@@ -1,0 +1,15 @@
+import { type ReactNode } from "react";
+
+interface PanelSectionProps {
+  heading: string;
+  children: ReactNode;
+}
+
+export function PanelSection({ heading, children }: PanelSectionProps) {
+  return (
+    <div className="bg-muted/30 rounded-lg p-3">
+      <p className="text-xs font-medium text-muted-foreground mb-2">{heading}</p>
+      {children}
+    </div>
+  );
+}

--- a/src/components/ShortcutOverlay.tsx
+++ b/src/components/ShortcutOverlay.tsx
@@ -37,6 +37,7 @@ function buildSections(): Section[] {
     {
       label: "View",
       rows: [
+        { action: "Document Info",  keys: [`${mod}I`] },
         { action: "Zoom In",        keys: [`${mod}+`] },
         { action: "Zoom Out",       keys: [`${mod}−`] },
         { action: "Fit Width",      keys: [`${mod}0`] },

--- a/src/components/Toolbar.test.tsx
+++ b/src/components/Toolbar.test.tsx
@@ -16,6 +16,8 @@ function renderToolbar(props: {
   onSave?: () => void;
   onUndo?: () => void;
   onRedo?: () => void;
+  infoPanelOpen?: boolean;
+  onToggleInfo?: () => void;
 }) {
   return render(
     <SidebarProvider>
@@ -29,6 +31,8 @@ function renderToolbar(props: {
         onSave={props.onSave ?? vi.fn()}
         onUndo={props.onUndo ?? vi.fn()}
         onRedo={props.onRedo ?? vi.fn()}
+        infoPanelOpen={props.infoPanelOpen ?? false}
+        onToggleInfo={props.onToggleInfo ?? vi.fn()}
       />
     </SidebarProvider>
   );
@@ -168,5 +172,42 @@ describe("Toolbar", () => {
 
     await userEvent.click(toggle);
     expect(useAppStore.getState().theme).toBe("system");
+  });
+});
+
+describe("Info button", () => {
+  it("renders a button with aria-label 'Document info'", () => {
+    renderToolbar({});
+    expect(screen.getByRole("button", { name: /document info/i })).toBeInTheDocument();
+  });
+
+  it("is disabled when hasDocument is false", () => {
+    renderToolbar({ hasDocument: false });
+    expect(screen.getByRole("button", { name: /document info/i })).toBeDisabled();
+  });
+
+  it("is enabled when hasDocument is true", () => {
+    renderToolbar({ hasDocument: true });
+    expect(screen.getByRole("button", { name: /document info/i })).not.toBeDisabled();
+  });
+
+  it("calls onToggleInfo when clicked", async () => {
+    const onToggleInfo = vi.fn();
+    renderToolbar({ hasDocument: true, onToggleInfo });
+    await userEvent.click(screen.getByRole("button", { name: /document info/i }));
+    expect(onToggleInfo).toHaveBeenCalledOnce();
+  });
+
+  it("uses secondary variant when infoPanelOpen is true", () => {
+    renderToolbar({ hasDocument: true, infoPanelOpen: true });
+    const btn = screen.getByRole("button", { name: /document info/i });
+    // secondary variant adds bg-secondary to the button
+    expect(btn.className).toMatch(/bg-secondary/);
+  });
+
+  it("uses ghost variant when infoPanelOpen is false", () => {
+    renderToolbar({ hasDocument: true, infoPanelOpen: false });
+    const btn = screen.getByRole("button", { name: /document info/i });
+    expect(btn.className).not.toMatch(/bg-secondary/);
   });
 });

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,5 +1,6 @@
 import {
   FolderOpen,
+  Info,
   Maximize2,
   Monitor,
   Moon,
@@ -36,6 +37,8 @@ interface ToolbarProps {
   onSave(): void;
   onUndo(): void;
   onRedo(): void;
+  infoPanelOpen: boolean;
+  onToggleInfo(): void;
 }
 
 const THEME_CYCLE: Theme[] = ["system", "light", "dark"];
@@ -52,7 +55,7 @@ const THEME_LABEL: Record<Theme, string> = {
   dark: "Theme: Dark",
 };
 
-export function Toolbar({ onOpen, loading, hasDocument, isDirty, canUndo, canRedo, onSave, onUndo, onRedo }: ToolbarProps) {
+export function Toolbar({ onOpen, loading, hasDocument, isDirty, canUndo, canRedo, onSave, onUndo, onRedo, infoPanelOpen, onToggleInfo }: ToolbarProps) {
   const theme = useAppStore((s) => s.theme);
   const setTheme = useAppStore((s) => s.setTheme);
   const zoom = useAppStore((s) => s.zoom);
@@ -197,6 +200,21 @@ export function Toolbar({ onOpen, loading, hasDocument, isDirty, canUndo, canRed
         </ButtonGroup>
 
         <div className="flex-1" />
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size="icon"
+              variant={infoPanelOpen ? "secondary" : "ghost"}
+              onClick={onToggleInfo}
+              disabled={!hasDocument}
+              aria-label="Document info"
+            >
+              <Info className="size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Document Info</TooltipContent>
+        </Tooltip>
 
         <Tooltip>
           <TooltipTrigger asChild>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,49 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,88 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Tabs as TabsPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-horizontal:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> &
+  VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 text-sm outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -105,3 +105,39 @@ describe("selectAll", () => {
     expect(pages).toEqual([0, 1]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// infoPanelOpen
+// ---------------------------------------------------------------------------
+
+describe("infoPanelOpen", () => {
+  beforeEach(() => {
+    useAppStore.setState({ infoPanelOpen: false });
+  });
+
+  it("starts false", () => {
+    expect(useAppStore.getState().infoPanelOpen).toBe(false);
+  });
+
+  it("toggleInfoPanel() sets it to true", () => {
+    useAppStore.getState().toggleInfoPanel();
+    expect(useAppStore.getState().infoPanelOpen).toBe(true);
+  });
+
+  it("toggleInfoPanel() called twice returns to false", () => {
+    useAppStore.getState().toggleInfoPanel();
+    useAppStore.getState().toggleInfoPanel();
+    expect(useAppStore.getState().infoPanelOpen).toBe(false);
+  });
+
+  it("setInfoPanelOpen(true) sets it true", () => {
+    useAppStore.getState().setInfoPanelOpen(true);
+    expect(useAppStore.getState().infoPanelOpen).toBe(true);
+  });
+
+  it("setInfoPanelOpen(false) sets it false", () => {
+    useAppStore.setState({ infoPanelOpen: true });
+    useAppStore.getState().setInfoPanelOpen(false);
+    expect(useAppStore.getState().infoPanelOpen).toBe(false);
+  });
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -25,6 +25,9 @@ interface AppStore {
   selectPageRange(from: number, to: number): void;
   clearSelection(): void;
   selectAll(count: number): void;
+  infoPanelOpen: boolean;
+  setInfoPanelOpen(open: boolean): void;
+  toggleInfoPanel(): void;
 }
 
 export const ZOOM_STEPS = [25, 50, 75, 100, 125, 150, 200, 300, 400];
@@ -67,6 +70,9 @@ export const useAppStore = create<AppStore>()(
         for (let i = 0; i < count; i++) next.add(i);
         set({ selectedPages: next });
       },
+      infoPanelOpen: false,
+      setInfoPanelOpen: (open) => set({ infoPanelOpen: open }),
+      toggleInfoPanel: () => set((s) => ({ infoPanelOpen: !s.infoPanelOpen })),
     }),
     {
       name: "collate-settings",


### PR DESCRIPTION
## Summary

- Adds `InfoPanel` — a Sheet with **Info** and **Keywords** tabs displaying PDF metadata
- Refactors layout to contained sections (`bg-muted/30`, `rounded-lg`) with inline labels
- Adds `RowList` helper that auto-inserts separators between rows
- Adds `Info` icon to the sheet title header

## Test plan

- [ ] Open a PDF and trigger the Info panel — verify Info and Keywords tabs render correctly
- [ ] Verify loading skeleton appears while metadata is being fetched
- [ ] Verify all metadata rows display label/value pairs with correct alignment
- [ ] Verify panel is disabled when no document is open (per UI Affordance Rule)