### PR TITLE
feat: File → Open Recent submenu

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -450,6 +450,25 @@ fn find_open_recent_submenu<R: tauri::Runtime>(
     None
 }
 
+/// Returns the display label for a recent-file menu item.
+///
+/// Extracted as a pure function so it can be unit-tested without a Tauri runtime.
+fn format_recent_menu_label(path: &str, exists: bool) -> String {
+    let name = Path::new(path)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.to_owned());
+    if exists { name } else { format!("{name} (not found)") }
+}
+
+/// Parses a `"recent-{n}"` menu-item ID and returns the index `n`, or `None`
+/// if the string doesn't match the expected pattern.
+///
+/// Extracted as a pure function so it can be unit-tested without a Tauri runtime.
+fn parse_recent_id(id: &str) -> Option<usize> {
+    id.strip_prefix("recent-")?.parse().ok()
+}
+
 /// Rebuild the "Open Recent" submenu contents to match `paths`.
 ///
 /// Called from the frontend after every open or clear action so the native
@@ -462,7 +481,10 @@ fn update_recent_menu(app: tauri::AppHandle, state: State<AppState>, paths: Vec<
 
     let Some(menu) = app.menu() else { return };
     let Ok(items) = menu.items() else { return };
-    let Some(sub) = find_open_recent_submenu(items) else { return };
+    let Some(sub) = find_open_recent_submenu(items) else {
+        eprintln!("[collate] update_recent_menu: open-recent submenu not found");
+        return;
+    };
 
     // Drain all existing items from the submenu.
     while let Ok(Some(_)) = sub.remove_at(0) {}
@@ -474,11 +496,7 @@ fn update_recent_menu(app: tauri::AppHandle, state: State<AppState>, paths: Vec<
     } else {
         for (i, path) in paths.iter().enumerate() {
             let exists = Path::new(path).exists();
-            let name = Path::new(path)
-                .file_name()
-                .map(|n| n.to_string_lossy().into_owned())
-                .unwrap_or_else(|| path.clone());
-            let label = if exists { name } else { format!("{name} (not found)") };
+            let label = format_recent_menu_label(path, exists);
             if let Ok(item) = MenuItem::with_id(&app, format!("recent-{i}"), label, exists, None::<&str>) {
                 let _ = sub.append(&item);
             }
@@ -627,7 +645,7 @@ pub fn run() {
                 "report-bug"   => { let _ = app.emit("menu-report-bug", ()); }
                 "clear-recent" => { let _ = app.emit("menu-clear-recent", ()); }
                 id if id.starts_with("recent-") => {
-                    if let Ok(idx) = id.trim_start_matches("recent-").parse::<usize>() {
+                    if let Some(idx) = parse_recent_id(id) {
                         let paths = app.state::<AppState>().recent_paths.lock().unwrap().clone();
                         if let Some(path) = paths.get(idx) {
                             let _ = app.emit("menu-open-recent", path.clone());
@@ -802,6 +820,50 @@ mod tests {
         let state = empty_state();
         assert_eq!(require_doc(4, &state).err().unwrap(), "document 4 not found");
         assert_eq!(require_doc(5, &state).err().unwrap(), "document 5 not found");
+    }
+
+    // format_recent_menu_label
+
+    #[test]
+    fn format_recent_menu_label_returns_filename_when_exists() {
+        assert_eq!(format_recent_menu_label("/docs/report.pdf", true), "report.pdf");
+    }
+
+    #[test]
+    fn format_recent_menu_label_appends_not_found_when_missing() {
+        assert_eq!(
+            format_recent_menu_label("/docs/report.pdf", false),
+            "report.pdf (not found)"
+        );
+    }
+
+    #[test]
+    fn format_recent_menu_label_falls_back_to_full_path_when_no_filename() {
+        // A path like "/" has no file_name component.
+        assert_eq!(format_recent_menu_label("/", false), "/ (not found)");
+    }
+
+    // parse_recent_id
+
+    #[test]
+    fn parse_recent_id_returns_index_for_valid_ids() {
+        assert_eq!(parse_recent_id("recent-0"), Some(0));
+        assert_eq!(parse_recent_id("recent-9"), Some(9));
+    }
+
+    #[test]
+    fn parse_recent_id_returns_none_for_empty_suffix() {
+        assert_eq!(parse_recent_id("recent-"), None);
+    }
+
+    #[test]
+    fn parse_recent_id_returns_none_for_non_numeric_suffix() {
+        assert_eq!(parse_recent_id("recent-abc"), None);
+    }
+
+    #[test]
+    fn parse_recent_id_returns_none_for_unrelated_id() {
+        assert_eq!(parse_recent_id("open-recent"), None);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 
 use pdfium_render::prelude::*;
 use serde::Serialize;
-use tauri::{http, menu::MenuItemKind, Emitter, Manager, State};
+use tauri::{http, menu::{MenuItem, MenuItemKind, PredefinedMenuItem, Submenu}, Emitter, Manager, State};
 
 mod menu;
 mod render;
@@ -45,6 +45,10 @@ struct AppState {
     // without holding State<'_> (which has a lifetime) across an await point.
     documents: Mutex<HashMap<u32, Arc<DocumentEntry>>>,
     next_id: AtomicU32,
+    /// Most-recently-opened file paths, mirrored from the frontend's Zustand
+    /// store. Stored here so on_menu_event can resolve "recent-{n}" clicks
+    /// back to a full path without a round-trip to the frontend.
+    recent_paths: Mutex<Vec<String>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -416,6 +420,79 @@ fn set_theme_checks(app: &tauri::AppHandle, selected: &str) {
 }
 
 // ---------------------------------------------------------------------------
+// Open Recent menu helpers
+// ---------------------------------------------------------------------------
+
+/// Walk `items` and return the first Submenu whose ID is "open-recent".
+/// Recurses one level into any other Submenu encountered.
+///
+/// Menu::get() does not reliably recurse in all Tauri 2.x releases (see
+/// apply_theme_checks), so we traverse manually — same pattern as the other
+/// menu helpers in this file.
+fn find_open_recent_submenu<R: tauri::Runtime>(
+    items: Vec<MenuItemKind<R>>,
+) -> Option<Submenu<R>> {
+    for item in items {
+        match item {
+            MenuItemKind::Submenu(sub) => {
+                if sub.id().as_ref() == "open-recent" {
+                    return Some(sub);
+                }
+                if let Ok(children) = sub.items() {
+                    if let Some(found) = find_open_recent_submenu(children) {
+                        return Some(found);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Rebuild the "Open Recent" submenu contents to match `paths`.
+///
+/// Called from the frontend after every open or clear action so the native
+/// menu stays in sync with the Zustand store. Missing files are shown with a
+/// "(not found)" suffix and their menu items are disabled.
+#[tauri::command]
+fn update_recent_menu(app: tauri::AppHandle, state: State<AppState>, paths: Vec<String>) {
+    // Store paths so on_menu_event can resolve "recent-{n}" to a full path.
+    *state.recent_paths.lock().unwrap() = paths.clone();
+
+    let Some(menu) = app.menu() else { return };
+    let Ok(items) = menu.items() else { return };
+    let Some(sub) = find_open_recent_submenu(items) else { return };
+
+    // Drain all existing items from the submenu.
+    while let Ok(Some(_)) = sub.remove_at(0) {}
+
+    if paths.is_empty() {
+        if let Ok(item) = MenuItem::with_id(&app, "recent-empty", "No Recent Items", false, None::<&str>) {
+            let _ = sub.append(&item);
+        }
+    } else {
+        for (i, path) in paths.iter().enumerate() {
+            let exists = Path::new(path).exists();
+            let name = Path::new(path)
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| path.clone());
+            let label = if exists { name } else { format!("{name} (not found)") };
+            if let Ok(item) = MenuItem::with_id(&app, format!("recent-{i}"), label, exists, None::<&str>) {
+                let _ = sub.append(&item);
+            }
+        }
+        if let Ok(sep) = PredefinedMenuItem::separator(&app) {
+            let _ = sub.append(&sep);
+        }
+        if let Ok(clear) = MenuItem::with_id(&app, "clear-recent", "Clear Recent", true, None::<&str>) {
+            let _ = sub.append(&clear);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // PDF document menu helpers
 // ---------------------------------------------------------------------------
 
@@ -548,12 +625,22 @@ pub fn run() {
                 "theme-light"  => { set_theme_checks(app, "light");  let _ = app.emit("menu-theme", "light"); }
                 "theme-dark"   => { set_theme_checks(app, "dark");   let _ = app.emit("menu-theme", "dark"); }
                 "report-bug"   => { let _ = app.emit("menu-report-bug", ()); }
+                "clear-recent" => { let _ = app.emit("menu-clear-recent", ()); }
+                id if id.starts_with("recent-") => {
+                    if let Ok(idx) = id.trim_start_matches("recent-").parse::<usize>() {
+                        let paths = app.state::<AppState>().recent_paths.lock().unwrap().clone();
+                        if let Some(path) = paths.get(idx) {
+                            let _ = app.emit("menu-open-recent", path.clone());
+                        }
+                    }
+                }
                 _ => {}
             }
         })
         .manage(AppState {
             documents: Mutex::new(HashMap::new()),
             next_id: AtomicU32::new(0),
+            recent_paths: Mutex::new(vec![]),
         })
         // ---------------------------------------------------------------------------
         // Page image protocol — collate://localhost/{doc_id}/{page_index}/{width}
@@ -634,6 +721,7 @@ pub fn run() {
             get_document_info,
             set_menu_theme,
             set_pdf_menus_enabled,
+            update_recent_menu,
             save_document,
             undo_document,
             redo_document,
@@ -658,6 +746,7 @@ mod tests {
         AppState {
             documents: Mutex::new(HashMap::new()),
             next_id: AtomicU32::new(0),
+            recent_paths: Mutex::new(vec![]),
         }
     }
 

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -7,6 +7,10 @@ use tauri::{
 ///
 /// Menu event IDs used by the on_menu_event handler in lib.rs:
 ///   "open"               — File → Open…
+///   "open-recent"        — File → Open Recent (submenu; populated by update_recent_menu IPC)
+///   "recent-{n}"         — File → Open Recent → individual file (n = 0..9)
+///   "recent-empty"       — File → Open Recent → "No Recent Items" placeholder
+///   "clear-recent"       — File → Open Recent → Clear Recent
 ///   "save"               — File → Save
 ///   "save-as"            — File → Save As…
 ///   "close"              — File → Close
@@ -40,7 +44,11 @@ pub fn build_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
     let app_menu = Submenu::with_items(app, "Collate", true, &[&about, &sep, &quit_app])?;
 
     // ── File ───────────────────────────────────────────────────────────────
-    let open    = MenuItem::with_id(app, "open",    "Open…",    true,  Some("CmdOrCtrl+O"))?;
+    let open         = MenuItem::with_id(app, "open",         "Open…",           true,  Some("CmdOrCtrl+O"))?;
+    let recent_empty = MenuItem::with_id(app, "recent-empty", "No Recent Items",  false, None::<&str>)?;
+    let open_recent  = Submenu::with_id(app, "open-recent", "Open Recent", true)?;
+    open_recent.append(&recent_empty)?;
+    let sep_recent   = PredefinedMenuItem::separator(app)?;
     let save    = MenuItem::with_id(app, "save",    "Save",     false, Some("CmdOrCtrl+S"))?;
     let save_as = MenuItem::with_id(app, "save-as", "Save As…", false, Some("Shift+CmdOrCtrl+S"))?;
     let close   = MenuItem::with_id(app, "close",   "Close",    false, Some("CmdOrCtrl+W"))?;
@@ -49,7 +57,7 @@ pub fn build_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
     let quit_file = PredefinedMenuItem::quit(app, None)?;
     let file_menu = Submenu::with_items(
         app, "File", true,
-        &[&open, &save, &save_as, &close, &print, &sep_file, &quit_file],
+        &[&open, &open_recent, &sep_recent, &save, &save_as, &close, &print, &sep_file, &quit_file],
     )?;
 
     // ── Edit ───────────────────────────────────────────────────────────────

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,15 +55,13 @@ function App() {
   const infoPanelOpen = useAppStore((s) => s.infoPanelOpen);
   const setInfoPanelOpen = useAppStore((s) => s.setInfoPanelOpen);
   const toggleInfoPanel = useAppStore((s) => s.toggleInfoPanel);
-  const recentFiles = useAppStore((s) => s.recentFiles);
-
   // Apply theme (dark class on <html>) and keep it in sync with OS changes
   useTheme();
 
   // Sync the "Open Recent" submenu once on mount with whatever was persisted.
   useEffect(() => {
-    void invoke("update_recent_menu", { paths: recentFiles });
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    void invoke("update_recent_menu", { paths: useAppStore.getState().recentFiles });
+  }, []);
 
   // Sync native menu checkmarks whenever theme changes.
   // Fires on startup (picks up persisted value) and after toolbar cycle changes.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,9 +55,15 @@ function App() {
   const infoPanelOpen = useAppStore((s) => s.infoPanelOpen);
   const setInfoPanelOpen = useAppStore((s) => s.setInfoPanelOpen);
   const toggleInfoPanel = useAppStore((s) => s.toggleInfoPanel);
+  const recentFiles = useAppStore((s) => s.recentFiles);
 
   // Apply theme (dark class on <html>) and keep it in sync with OS changes
   useTheme();
+
+  // Sync the "Open Recent" submenu once on mount with whatever was persisted.
+  useEffect(() => {
+    void invoke("update_recent_menu", { paths: recentFiles });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Sync native menu checkmarks whenever theme changes.
   // Fires on startup (picks up persisted value) and after toolbar cycle changes.
@@ -141,21 +147,13 @@ function App() {
     setBugReportOpen(true);
   }
 
-  async function handleOpen() {
-    const path = await openDialog({
-      multiple: false,
-      filters: [{ name: "PDF", extensions: ["pdf"] }],
-    });
-
-    if (!path) return;
-
+  async function handleOpenPath(path: string) {
     setLoading(true);
-
-    if (manifest) {
-      await invoke("close_document", { docId: manifest.doc_id });
+    const current = manifestRef.current;
+    if (current) {
+      await invoke("close_document", { docId: current.doc_id });
     }
     setManifest(null);
-
     try {
       const m = await invoke<DocumentManifest>("open_document", { path });
       setManifest(m);
@@ -163,18 +161,22 @@ function App() {
       useAppStore.getState().clearSelection();
       useAppStore.getState().setIsDirty(false);
       void invoke("set_pdf_menus_enabled", { enabled: true });
+      useAppStore.getState().addRecentFile(path);
+      void invoke("update_recent_menu", { paths: useAppStore.getState().recentFiles });
     } catch (e) {
-      const message = String(e);
-      toast.error(message, {
-        duration: 6000,
-        action: {
-          label: <BugIcon className="size-4" />,
-          onClick: () => openBugReportForError(message),
-        },
-      });
+      showError(String(e));
     } finally {
       setLoading(false);
     }
+  }
+
+  async function handleOpen() {
+    const path = await openDialog({
+      multiple: false,
+      filters: [{ name: "PDF", extensions: ["pdf"] }],
+    });
+    if (!path) return;
+    await handleOpenPath(path);
   }
 
   // Handle Mod+= for zoom in (mirrors the native menu's CmdOrCtrl+= shortcut).
@@ -253,6 +255,13 @@ function App() {
     const unlistenPrint   = listen<void>("menu-print",   () => {
       toast.error("Print is not yet implemented.", { duration: 4000 });
     });
+    const unlistenOpenRecent = listen<string>("menu-open-recent", (e) => {
+      void handleOpenPath(e.payload);
+    });
+    const unlistenClearRecent = listen<void>("menu-clear-recent", () => {
+      useAppStore.getState().clearRecentFiles();
+      void invoke("update_recent_menu", { paths: [] });
+    });
     return () => {
       unlistenOpen.then((fn) => fn());
       unlistenClose.then((fn) => fn());
@@ -276,6 +285,8 @@ function App() {
       unlistenRedo.then((fn) => fn());
       unlistenSelectAll.then((fn) => fn());
       unlistenPrint.then((fn) => fn());
+      unlistenOpenRecent.then((fn) => fn());
+      unlistenClearRecent.then((fn) => fn());
     };
     // handleOpen is defined in render scope but only reads stable refs/setState.
     // Omitting from deps avoids re-registering listeners on every render.

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -107,6 +107,45 @@ describe("selectAll", () => {
 });
 
 // ---------------------------------------------------------------------------
+// recentFiles
+// ---------------------------------------------------------------------------
+
+describe("recentFiles", () => {
+  beforeEach(() => {
+    useAppStore.setState({ recentFiles: [] });
+  });
+
+  it("starts empty", () => {
+    expect(useAppStore.getState().recentFiles).toEqual([]);
+  });
+
+  it("addRecentFile prepends to the list", () => {
+    useAppStore.getState().addRecentFile("/a.pdf");
+    useAppStore.getState().addRecentFile("/b.pdf");
+    expect(useAppStore.getState().recentFiles[0]).toBe("/b.pdf");
+  });
+
+  it("addRecentFile deduplicates (existing entry moves to front)", () => {
+    useAppStore.setState({ recentFiles: ["/a.pdf", "/b.pdf"] });
+    useAppStore.getState().addRecentFile("/b.pdf");
+    expect(useAppStore.getState().recentFiles).toEqual(["/b.pdf", "/a.pdf"]);
+  });
+
+  it("addRecentFile trims list to 10", () => {
+    for (let i = 0; i < 12; i++) {
+      useAppStore.getState().addRecentFile(`/${i}.pdf`);
+    }
+    expect(useAppStore.getState().recentFiles.length).toBe(10);
+  });
+
+  it("clearRecentFiles empties the list", () => {
+    useAppStore.setState({ recentFiles: ["/a.pdf"] });
+    useAppStore.getState().clearRecentFiles();
+    expect(useAppStore.getState().recentFiles).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // infoPanelOpen
 // ---------------------------------------------------------------------------
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -12,6 +12,9 @@ interface AppStore {
   setSidebarWidth(width: number): void;
   theme: Theme;
   setTheme(theme: Theme): void;
+  recentFiles: string[];
+  addRecentFile(path: string): void;
+  clearRecentFiles(): void;
   zoom: number;
   setZoom(zoom: number): void;
   zoomMode: ZoomMode;
@@ -41,6 +44,13 @@ export const useAppStore = create<AppStore>()(
       setSidebarWidth: (width) => set({ sidebarWidth: width }),
       theme: "system",
       setTheme: (theme) => set({ theme }),
+      recentFiles: [],
+      addRecentFile: (path) =>
+        set((s) => {
+          const without = s.recentFiles.filter((p) => p !== path);
+          return { recentFiles: [path, ...without].slice(0, 10) };
+        }),
+      clearRecentFiles: () => set({ recentFiles: [] }),
       zoom: 75,
       setZoom: (zoom) => set({ zoom }),
       zoomMode: "manual",
@@ -77,7 +87,7 @@ export const useAppStore = create<AppStore>()(
     {
       name: "collate-settings",
       // Only persist user preferences, not transient document state
-      partialize: (state) => ({ theme: state.theme }),
+      partialize: (state) => ({ theme: state.theme, recentFiles: state.recentFiles }),
     }
   )
 );


### PR DESCRIPTION
Related to #8

## Summary

- Adds a native **File → Open Recent** submenu tracking the last 10 opened PDFs
- Recent files persist across sessions via Zustand + localStorage
- Missing files shown as disabled with a "(not found)" suffix
- **Clear Recent** action at the bottom of the submenu resets the list

## Implementation notes

- `update_recent_menu` IPC command rebuilds the native submenu from the frontend's path list; called on mount (to restore persisted state) and after every open/clear
- `AppState.recent_paths` mirrors the list in Rust so `on_menu_event` can resolve `recent-{n}` clicks back to full paths without a round-trip
- `handleOpen` refactored to delegate to new `handleOpenPath(path)`, which is also used by the `menu-open-recent` listener

## Test plan

- [ ] `make test-frontend` passes (5 new store tests for `recentFiles`)
- [ ] `make test-rust` passes
- [ ] Open a PDF → appears in File → Open Recent
- [ ] Quit and relaunch → file still appears in submenu (localStorage persistence)
- [ ] Open 11 different files → only 10 appear
- [ ] Open the same file twice → deduplicated, moves to top
- [ ] Move a file to trash → relaunch shows it dimmed as "(not found)", unclickable
- [ ] Click a recent file → opens correctly
- [ ] Clear Recent → submenu shows "No Recent Items"