### PR TITLE
feat: tabbed multi-document with drag-to-reorder (P1.5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,10 @@ Tim is learning Rust through this project. He knows Go, bash, and unix tooling w
 
 Any button, menu item, toolbar action, or context menu item that requires an open document **must be disabled** (not hidden) when no document is open. This includes — but is not limited to — zoom controls, page navigation, close, print, and any document-mutation actions. Use shadcn/ui's `disabled` prop (which maps to the native `disabled` attribute and ARIA semantics). The enabled/disabled state must derive from the zustand store's document presence flag, not from ad-hoc local checks.
 
+## Long Text Truncation Rule
+
+Use `middleTruncate(str, maxLength)` from `src/lib/truncate.ts` when displaying long text (filenames, paths, labels) in the UI. It preserves both ends of the string; for filenames it also keeps the extension intact. Do not use the CSS `truncate` class for text that has semantic meaning at both ends.
+
 ## Key Design Principles (from spec)
 
 - Non-destructive by default. Source files are never modified until explicit save.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -748,6 +748,10 @@ For each page that has form fields, React renders a `<FormFieldOverlay>` positio
 
 Each input is positioned using the normalized coordinates from the backend (Section 5.3). Percentage-based positioning means the overlay scales automatically with zoom.
 
+### 7.7 UI Conventions
+
+**Long text truncation:** Use `middleTruncate(str, maxLength)` from `src/lib/truncate.ts` wherever long text needs to be shortened (filenames, paths, labels). It preserves both ends of the string and, for filenames, keeps the extension intact. Do not use the CSS `truncate` class for text that has semantic meaning at both ends.
+
 ---
 
 ## 8. Build & Distribution

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/geist": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/geist": "^5.2.8",
     "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-virtual": "^3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@fontsource-variable/geist':
         specifier: ^5.2.8
         version: 5.2.8
@@ -319,6 +328,28 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@dotenvx/dotenvx@1.60.0':
     resolution: {integrity: sha512-zWepVRNan/5gCALiT/QCHVsmxvq81xenBqGRyoTUy+ClJ+Mgs+tTJ6h4f65nqs8ijVFe6xg4lIQAIwe+HfgWXg==}
@@ -3703,6 +3734,31 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@dotenvx/dotenvx@1.60.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/modifiers':
+        specifier: ^9.0.0
+        version: 9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@dnd-kit/sortable':
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
@@ -339,6 +342,12 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  '@dnd-kit/modifiers@9.0.0':
+    resolution: {integrity: sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
 
   '@dnd-kit/sortable@10.0.0':
     resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
@@ -3746,6 +3755,13 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/modifiers@9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
       tslib: 2.8.1
 
   '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -517,6 +517,7 @@ fn update_recent_menu(app: tauri::AppHandle, state: State<AppState>, paths: Vec<
 const PDF_MENU_IDS: &[&str] = &[
     "close", "print", "undo", "redo", "select-all", "find",
     "save", "save-as",
+    "next-tab", "prev-tab",
     "zoom-in", "zoom-out", "zoom-fit-width",
     "doc-info",
     // Document menu
@@ -635,6 +636,8 @@ pub fn run() {
                 "display-continuous" => { set_display_checks(app, "continuous"); let _ = app.emit("menu-display", "continuous"); }
                 "display-single"     => { set_display_checks(app, "single");     let _ = app.emit("menu-display", "single"); }
                 "display-spread"     => { set_display_checks(app, "spread");     let _ = app.emit("menu-display", "spread"); }
+                "next-tab"       => { let _ = app.emit("menu-next-tab",       ()); }
+                "prev-tab"       => { let _ = app.emit("menu-prev-tab",       ()); }
                 "zoom-in"        => { let _ = app.emit("menu-zoom-in",        ()); }
                 "zoom-out"       => { let _ = app.emit("menu-zoom-out",       ()); }
                 "zoom-fit-width" => { let _ = app.emit("menu-zoom-fit-width", ()); }

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -26,6 +26,8 @@ use tauri::{
 ///   "split"              — Document → Split Document…
 ///   "merge"              — Document → Merge Document…
 ///   "import-pages"       — Document → Import Pages…
+///   "next-tab"           — View → Next Tab
+///   "prev-tab"           — View → Previous Tab
 ///   "display-continuous" — View → Page Display → Continuous Scroll
 ///   "display-single"     — View → Page Display → Single Page
 ///   "display-spread"     — View → Page Display → Two-Page Spread
@@ -102,6 +104,23 @@ pub fn build_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
         ],
     )?;
 
+    // ── View → Tab navigation ─────────────────────────────────────────────
+    // macOS: ⌘⇧] / ⌘⇧[  (matches Safari / Terminal)
+    // Win/Linux: Ctrl+PageDown / Ctrl+PageUp  (matches Chrome DevTools / VS Code)
+    let next_tab_accel: Option<&str> = if cfg!(target_os = "macos") {
+        Some("Shift+CmdOrCtrl+]")
+    } else {
+        Some("Ctrl+PageDown")
+    };
+    let prev_tab_accel: Option<&str> = if cfg!(target_os = "macos") {
+        Some("Shift+CmdOrCtrl+[")
+    } else {
+        Some("Ctrl+PageUp")
+    };
+    let next_tab  = MenuItem::with_id(app, "next-tab",  "Next Tab",      false, next_tab_accel)?;
+    let prev_tab  = MenuItem::with_id(app, "prev-tab",  "Previous Tab",  false, prev_tab_accel)?;
+    let sep_tabs  = PredefinedMenuItem::separator(app)?;
+
     // ── View → Page Display ────────────────────────────────────────────────
     let display_continuous = CheckMenuItem::with_id(app, "display-continuous", "Continuous Scroll", false, true,  None::<&str>)?;
     let display_single     = CheckMenuItem::with_id(app, "display-single",     "Single Page",       false, false, None::<&str>)?;
@@ -129,7 +148,7 @@ pub fn build_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
         app,
         "View",
         true,
-        &[&display_menu, &sep_display, &doc_info, &sep_info, &zoom_menu, &sep_zoom, &appearance],
+        &[&next_tab, &prev_tab, &sep_tabs, &display_menu, &sep_display, &doc_info, &sep_info, &zoom_menu, &sep_zoom, &appearance],
     )?;
 
     // ── Help (required by macOS HIG) ───────────────────────────────────────

--- a/src/App.css
+++ b/src/App.css
@@ -15,6 +15,7 @@ body[data-sidebar-dragging] [data-slot="sidebar-container"] {
 @theme inline {
   --font-heading: var(--font-sans);
   --font-sans: 'Geist Variable', sans-serif;
+  --color-tab-inactive: var(--tab-inactive);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -56,6 +57,7 @@ body[data-sidebar-dragging] [data-slot="sidebar-container"] {
 }
 
 :root {
+  --tab-inactive: oklch(0.935 0 0);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -91,6 +93,7 @@ body[data-sidebar-dragging] [data-slot="sidebar-container"] {
 }
 
 .dark {
+  --tab-inactive: oklch(0.225 0 0);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
@@ -122,6 +125,11 @@ body[data-sidebar-dragging] [data-slot="sidebar-container"] {
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+}
+
+html, body {
+  overflow: hidden;
+  overscroll-behavior: none;
 }
 
 @layer base {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, fireEvent, act } from "@testing-library/react"
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import App from "./App";
-import { useAppStore } from "@/store";
+import { useAppStore, type TabEntry } from "@/store";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
@@ -14,6 +14,11 @@ vi.mock("@tauri-apps/api/event", () => ({
 }));
 vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn().mockResolvedValue(null) }));
 vi.mock("@tauri-apps/api/app", () => ({ getVersion: vi.fn().mockResolvedValue("0.0.0") }));
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: vi.fn().mockResolvedValue(vi.fn()),
+  }),
+}));
 vi.mock("sonner", async (importOriginal) => {
   const actual = await importOriginal<typeof import("sonner")>();
   return { ...actual, toast: { ...actual.toast, error: vi.fn() } };
@@ -34,7 +39,15 @@ const MOCK_MANIFEST = {
 };
 
 beforeEach(() => {
-  useAppStore.setState({ theme: "system", zoom: 75, zoomMode: "manual", activePage: 0 });
+  useAppStore.setState({
+    theme: "system",
+    zoom: 75,
+    zoomMode: "manual",
+    activePage: 0,
+    tabs: [],
+    activeDocId: null,
+    docViewStates: new Map(),
+  });
   (invoke as Mock).mockResolvedValue(undefined);
   (openDialog as Mock).mockResolvedValue(null);
 });
@@ -165,5 +178,134 @@ describe("Edit > Select All menu event", () => {
     });
 
     expect(useAppStore.getState().selectedPages.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tab navigation — keyboard shortcuts
+// ---------------------------------------------------------------------------
+
+const TAB_1: TabEntry = {
+  docId: 1, filename: "a.pdf", path: "/a.pdf",
+  pageCount: 1, pageSizes: [], canUndo: false, canRedo: false, isDirty: false,
+};
+const TAB_2: TabEntry = {
+  docId: 2, filename: "b.pdf", path: "/b.pdf",
+  pageCount: 1, pageSizes: [], canUndo: false, canRedo: false, isDirty: false,
+};
+const TAB_3: TabEntry = {
+  docId: 3, filename: "c.pdf", path: "/c.pdf",
+  pageCount: 1, pageSizes: [], canUndo: false, canRedo: false, isDirty: false,
+};
+
+describe("Tab navigation keyboard shortcuts", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      tabs: [TAB_1, TAB_2, TAB_3],
+      activeDocId: 1,
+      docViewStates: new Map(),
+    });
+  });
+
+  it("⌘} moves to next tab", () => {
+    render(<App />);
+    fireEvent.keyDown(window, { key: "}", metaKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(2);
+  });
+
+  it("⌘{ moves to previous tab", () => {
+    useAppStore.setState({ activeDocId: 2 });
+    render(<App />);
+    fireEvent.keyDown(window, { key: "{", metaKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(1);
+  });
+
+  it("next tab wraps from last to first", () => {
+    useAppStore.setState({ activeDocId: 3 });
+    render(<App />);
+    fireEvent.keyDown(window, { key: "}", metaKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(1);
+  });
+
+  it("prev tab wraps from first to last", () => {
+    render(<App />);
+    fireEvent.keyDown(window, { key: "{", metaKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(3);
+  });
+
+  it("Ctrl+Tab moves to next tab", () => {
+    render(<App />);
+    fireEvent.keyDown(window, { key: "Tab", ctrlKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(2);
+  });
+
+  it("Ctrl+Shift+Tab moves to previous tab", () => {
+    useAppStore.setState({ activeDocId: 2 });
+    render(<App />);
+    fireEvent.keyDown(window, { key: "Tab", ctrlKey: true, shiftKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(1);
+  });
+
+  it("⌘1 / Ctrl+1 jumps to first tab", () => {
+    useAppStore.setState({ activeDocId: 3 });
+    render(<App />);
+    fireEvent.keyDown(window, { key: "1", metaKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(1);
+  });
+
+  it("⌘2 / Ctrl+2 jumps to second tab", () => {
+    render(<App />);
+    fireEvent.keyDown(window, { key: "2", ctrlKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(2);
+  });
+
+  it("⌘9 / Ctrl+9 jumps to last tab when fewer than 9 tabs open", () => {
+    render(<App />);
+    fireEvent.keyDown(window, { key: "9", metaKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(3);
+  });
+
+  it("does nothing when only one tab is open", () => {
+    useAppStore.setState({ tabs: [TAB_1], activeDocId: 1 });
+    render(<App />);
+    fireEvent.keyDown(window, { key: "}", metaKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(1);
+  });
+
+  it("does nothing when no tabs are open", () => {
+    useAppStore.setState({ tabs: [], activeDocId: null });
+    render(<App />);
+    fireEvent.keyDown(window, { key: "}", metaKey: true });
+    expect(useAppStore.getState().activeDocId).toBeNull();
+  });
+});
+
+describe("Tab navigation menu events", () => {
+  let menuHandlers: Record<string, () => void>;
+
+  beforeEach(() => {
+    menuHandlers = {};
+    useAppStore.setState({
+      tabs: [TAB_1, TAB_2, TAB_3],
+      activeDocId: 1,
+      docViewStates: new Map(),
+    });
+    (listen as Mock).mockImplementation((event: string, cb: () => void) => {
+      menuHandlers[event] = cb;
+      return Promise.resolve(vi.fn());
+    });
+  });
+
+  it("menu-next-tab moves to next tab", async () => {
+    render(<App />);
+    await act(async () => { menuHandlers["menu-next-tab"]?.(); });
+    expect(useAppStore.getState().activeDocId).toBe(2);
+  });
+
+  it("menu-prev-tab moves to previous tab", async () => {
+    useAppStore.setState({ activeDocId: 2 });
+    render(<App />);
+    await act(async () => { menuHandlers["menu-prev-tab"]?.(); });
+    expect(useAppStore.getState().activeDocId).toBe(1);
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -383,7 +383,7 @@ function App() {
     // strip appropriate for page thumbnails.
     <SidebarProvider
       defaultOpen={true}
-      className="h-screen overflow-hidden"
+      className="h-screen overflow-hidden overscroll-none"
       style={{ "--sidebar-width": `${sidebarWidth}px` } as React.CSSProperties}
     >
       {activeTab && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,6 @@ import { PageSidebar } from "./components/PageSidebar";
 import { TabBar } from "./components/TabBar";
 import { Toolbar } from "./components/Toolbar";
 import { StatusBar } from "./components/StatusBar";
-import { Separator } from "@/components/ui/separator";
 import { Toaster } from "@/components/ui/sonner";
 import {
   Sidebar,
@@ -421,8 +420,6 @@ function App() {
             onReorder={reorderTabs}
           />
         )}
-
-        <Separator />
 
         <div className="relative flex-1 overflow-hidden min-h-0">
           {activeTab ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { open as openDialog, save as saveDialog } from "@tauri-apps/plugin-dialo
 import { invoke } from "@tauri-apps/api/core";
 import { getVersion } from "@tauri-apps/api/app";
 import { listen } from "@tauri-apps/api/event";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { toast } from "sonner";
 import { BugIcon } from "lucide-react";
 import { BugReportDialog } from "./components/BugReportDialog";
@@ -11,6 +12,7 @@ import { ShortcutOverlay } from "./components/ShortcutOverlay";
 import { EmptyState } from "./components/EmptyState";
 import { PageViewer, PageViewerHandle } from "./components/PageViewer";
 import { PageSidebar } from "./components/PageSidebar";
+import { TabBar } from "./components/TabBar";
 import { Toolbar } from "./components/Toolbar";
 import { StatusBar } from "./components/StatusBar";
 import { Separator } from "@/components/ui/separator";
@@ -20,34 +22,26 @@ import {
   SidebarInset,
   SidebarProvider,
 } from "@/components/ui/sidebar";
-import { useAppStore, ZOOM_STEPS, PageDisplay } from "@/store";
+import { useAppStore, ZOOM_STEPS, PageDisplay, TabEntry } from "@/store";
 import { useTheme } from "@/hooks/useTheme";
 import { platformName } from "@/lib/platform";
-
-interface PageSize {
-  width_pts: number;
-  height_pts: number;
-}
-
-interface DocumentManifest {
-  doc_id: number;
-  page_count: number;
-  filename: string;
-  path: string;
-  page_sizes: PageSize[];
-  can_undo: boolean;
-  can_redo: boolean;
-}
+import { cn } from "@/lib/utils";
+import type { DocumentManifest } from "@/types";
 
 function App() {
-  const [manifest, setManifest] = useState<DocumentManifest | null>(null);
   const [loading, setLoading] = useState(false);
   const [bugReportOpen, setBugReportOpen] = useState(false);
   const [bugPrefill, setBugPrefill] = useState<{ title: string; description: string } | null>(null);
   const [showShortcuts, setShowShortcuts] = useState(false);
+  const [isDragOver, setIsDragOver] = useState(false);
 
   const viewerRef = useRef<PageViewerHandle>(null);
-  const manifestRef = useRef<DocumentManifest | null>(null);
+  // Stable ref for use inside event listener closures
+  const activeTabRef = useRef<TabEntry | null>(null);
+
+  const tabs = useAppStore((s) => s.tabs);
+  const activeDocId = useAppStore((s) => s.activeDocId);
+  const activeTab = tabs.find((t) => t.docId === activeDocId) ?? null;
   const sidebarWidth = useAppStore((s) => s.sidebarWidth);
   const theme = useAppStore((s) => s.theme);
   const setTheme = useAppStore((s) => s.setTheme);
@@ -55,8 +49,13 @@ function App() {
   const infoPanelOpen = useAppStore((s) => s.infoPanelOpen);
   const setInfoPanelOpen = useAppStore((s) => s.setInfoPanelOpen);
   const toggleInfoPanel = useAppStore((s) => s.toggleInfoPanel);
+  const reorderTabs = useAppStore((s) => s.reorderTabs);
+
   // Apply theme (dark class on <html>) and keep it in sync with OS changes
   useTheme();
+
+  // Keep ref in sync so event listeners always see the current active tab
+  useEffect(() => { activeTabRef.current = activeTab; }, [activeTab]);
 
   // Sync the "Open Recent" submenu once on mount with whatever was persisted.
   useEffect(() => {
@@ -64,25 +63,17 @@ function App() {
   }, []);
 
   // Sync native menu checkmarks whenever theme changes.
-  // Fires on startup (picks up persisted value) and after toolbar cycle changes.
   useEffect(() => {
     invoke("set_menu_theme", { theme });
   }, [theme]);
 
-  // Keep ref in sync so menu event listeners (registered once on mount) always
-  // see the current manifest rather than the stale closure value.
-  useEffect(() => { manifestRef.current = manifest; }, [manifest]);
-
-  async function handleClose() {
-    const m = manifestRef.current;
-    if (!m) return;
-    await invoke("close_document", { docId: m.doc_id });
-    await invoke("set_pdf_menus_enabled", { enabled: false });
-    setManifest(null);
-    useAppStore.getState().setActivePage(0);
-    useAppStore.getState().clearSelection();
-    useAppStore.getState().setIsDirty(false);
-    useAppStore.getState().setInfoPanelOpen(false);
+  async function handleCloseTab(docId: number) {
+    await invoke("close_document", { docId });
+    useAppStore.getState().removeTab(docId);
+    if (useAppStore.getState().tabs.length === 0) {
+      void invoke("set_pdf_menus_enabled", { enabled: false });
+      useAppStore.getState().setInfoPanelOpen(false);
+    }
   }
 
   function showError(message: string) {
@@ -96,11 +87,11 @@ function App() {
   }
 
   async function handleSave(path?: string) {
-    const m = manifestRef.current;
+    const m = activeTabRef.current;
     if (!m) return;
     const savePath = path ?? m.path;
     try {
-      await invoke("save_document", { docId: m.doc_id, path: savePath });
+      await invoke("save_document", { docId: m.docId, path: savePath });
       useAppStore.getState().setIsDirty(false);
     } catch (e) {
       showError(String(e));
@@ -113,22 +104,35 @@ function App() {
   }
 
   async function handleUndo() {
-    const m = manifestRef.current;
+    const m = activeTabRef.current;
     if (!m) return;
     try {
-      const next = await invoke<DocumentManifest>("undo_document", { docId: m.doc_id });
-      setManifest(next);
+      const next = await invoke<DocumentManifest>("undo_document", { docId: m.docId });
+      // Update the tab's canUndo/canRedo from the returned manifest
+      useAppStore.setState((s) => ({
+        tabs: s.tabs.map((t) =>
+          t.docId === next.doc_id
+            ? { ...t, canUndo: next.can_undo, canRedo: next.can_redo }
+            : t
+        ),
+      }));
     } catch (e) {
       showError(String(e));
     }
   }
 
   async function handleRedo() {
-    const m = manifestRef.current;
+    const m = activeTabRef.current;
     if (!m) return;
     try {
-      const next = await invoke<DocumentManifest>("redo_document", { docId: m.doc_id });
-      setManifest(next);
+      const next = await invoke<DocumentManifest>("redo_document", { docId: m.docId });
+      useAppStore.setState((s) => ({
+        tabs: s.tabs.map((t) =>
+          t.docId === next.doc_id
+            ? { ...t, canUndo: next.can_undo, canRedo: next.can_redo }
+            : t
+        ),
+      }));
     } catch (e) {
       showError(String(e));
     }
@@ -146,18 +150,16 @@ function App() {
   }
 
   async function handleOpenPath(path: string) {
-    setLoading(true);
-    const current = manifestRef.current;
-    if (current) {
-      await invoke("close_document", { docId: current.doc_id });
+    // Deduplicate: if already open, just switch to it
+    const existing = useAppStore.getState().tabs.find((t) => t.path === path);
+    if (existing) {
+      handleSwitchTab(existing.docId);
+      return;
     }
-    setManifest(null);
+    setLoading(true);
     try {
       const m = await invoke<DocumentManifest>("open_document", { path });
-      setManifest(m);
-      useAppStore.getState().setActivePage(0);
-      useAppStore.getState().clearSelection();
-      useAppStore.getState().setIsDirty(false);
+      useAppStore.getState().addTab(m);
       void invoke("set_pdf_menus_enabled", { enabled: true });
       useAppStore.getState().addRecentFile(path);
       void invoke("update_recent_menu", { paths: useAppStore.getState().recentFiles });
@@ -177,6 +179,36 @@ function App() {
     await handleOpenPath(path);
   }
 
+  function handleSwitchTab(docId: number) {
+    useAppStore.getState().setActiveDocId(docId);
+    // Scroll to the restored activePage after the virtualizer remounts
+    requestAnimationFrame(() => {
+      viewerRef.current?.scrollToPage(useAppStore.getState().activePage);
+    });
+  }
+
+  function navigateTabs(direction: 1 | -1) {
+    const { tabs, activeDocId } = useAppStore.getState();
+    if (tabs.length < 2) return;
+    const idx = tabs.findIndex((t) => t.docId === activeDocId);
+    if (idx === -1) return;
+    const next = tabs[(idx + direction + tabs.length) % tabs.length];
+    useAppStore.getState().setActiveDocId(next.docId);
+    requestAnimationFrame(() => {
+      viewerRef.current?.scrollToPage(useAppStore.getState().activePage);
+    });
+  }
+
+  function jumpToTab(n: number) {
+    const { tabs } = useAppStore.getState();
+    if (tabs.length === 0) return;
+    const target = tabs[Math.min(n - 1, tabs.length - 1)];
+    useAppStore.getState().setActiveDocId(target.docId);
+    requestAnimationFrame(() => {
+      viewerRef.current?.scrollToPage(useAppStore.getState().activePage);
+    });
+  }
+
   // Handle Mod+= for zoom in (mirrors the native menu's CmdOrCtrl+= shortcut).
   // Also handles ? (shortcut overlay) and Cmd+A (select all pages).
   useEffect(() => {
@@ -193,11 +225,24 @@ function App() {
         setShowShortcuts((v) => !v);
       }
       if ((e.metaKey || e.ctrlKey) && e.key === "a") {
-        const m = manifestRef.current;
+        const m = activeTabRef.current;
         if (m) {
           e.preventDefault();
-          useAppStore.getState().selectAll(m.page_count);
+          useAppStore.getState().selectAll(m.pageCount);
         }
+      }
+      // ⌘⇧] / ⌘⇧[ — next/prev tab (Mac; key is "}"/"}" because Shift+]/[ on US layout)
+      if (e.metaKey && e.key === "}") { e.preventDefault(); navigateTabs(1); }
+      if (e.metaKey && e.key === "{") { e.preventDefault(); navigateTabs(-1); }
+      // Ctrl+Tab / Ctrl+Shift+Tab — next/prev tab (Windows/Linux)
+      if (e.ctrlKey && !e.metaKey && e.key === "Tab") {
+        e.preventDefault();
+        if (e.shiftKey) navigateTabs(-1); else navigateTabs(1);
+      }
+      // ⌘1–⌘9 / Ctrl+1–9 — jump to nth tab; ⌘9 / Ctrl+9 goes to last tab
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key >= "1" && e.key <= "9") {
+        e.preventDefault();
+        jumpToTab(parseInt(e.key, 10));
       }
     }
     window.addEventListener("keydown", onKeyDown);
@@ -207,7 +252,10 @@ function App() {
   // Listen for native menu events forwarded from the Rust backend
   useEffect(() => {
     const unlistenOpen  = listen<void>("menu-open",  () => handleOpen());
-    const unlistenClose = listen<void>("menu-close", () => handleClose());
+    const unlistenClose = listen<void>("menu-close", () => {
+      const { activeDocId } = useAppStore.getState();
+      if (activeDocId !== null) void handleCloseTab(activeDocId);
+    });
     const unlistenTheme = listen<string>("menu-theme", (e) =>
       setTheme(e.payload as "light" | "dark" | "system")
     );
@@ -247,8 +295,8 @@ function App() {
     const unlistenUndo      = listen<void>("menu-undo",       () => handleUndo());
     const unlistenRedo      = listen<void>("menu-redo",       () => handleRedo());
     const unlistenSelectAll = listen<void>("menu-select-all", () => {
-      const m = manifestRef.current;
-      if (m) useAppStore.getState().selectAll(m.page_count);
+      const m = activeTabRef.current;
+      if (m) useAppStore.getState().selectAll(m.pageCount);
     });
     const unlistenPrint   = listen<void>("menu-print",   () => {
       toast.error("Print is not yet implemented.", { duration: 4000 });
@@ -260,6 +308,8 @@ function App() {
       useAppStore.getState().clearRecentFiles();
       void invoke("update_recent_menu", { paths: [] });
     });
+    const unlistenNextTab = listen<void>("menu-next-tab", () => navigateTabs(1));
+    const unlistenPrevTab  = listen<void>("menu-prev-tab",  () => navigateTabs(-1));
     return () => {
       unlistenOpen.then((fn) => fn());
       unlistenClose.then((fn) => fn());
@@ -285,9 +335,45 @@ function App() {
       unlistenPrint.then((fn) => fn());
       unlistenOpenRecent.then((fn) => fn());
       unlistenClearRecent.then((fn) => fn());
+      unlistenNextTab.then((fn) => fn());
+      unlistenPrevTab.then((fn) => fn());
     };
     // handleOpen is defined in render scope but only reads stable refs/setState.
     // Omitting from deps avoids re-registering listeners on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Drag-and-drop: open PDFs dropped onto the window.
+  // Use a ref for the unlisten function so the Strict Mode double-invoke
+  // cleanup fires correctly even before the promise resolves.
+  useEffect(() => {
+    const cancelRef = { fn: null as (() => void) | null };
+    const promise = getCurrentWebview().onDragDropEvent((event) => {
+      if (event.payload.type === "enter" && event.payload.paths.length > 0) setIsDragOver(true);
+      if (event.payload.type === "leave" || event.payload.type === "cancel") setIsDragOver(false);
+      if (event.payload.type === "drop") {
+        setIsDragOver(false);
+        for (const path of event.payload.paths) {
+          if (path.toLowerCase().endsWith(".pdf")) void handleOpenPath(path);
+        }
+      }
+    });
+    promise.then((fn) => {
+      // If cleanup already ran before this resolved, unregister immediately
+      if (cancelRef.fn === null) {
+        cancelRef.fn = fn;
+      } else {
+        fn();
+      }
+    });
+    return () => {
+      if (cancelRef.fn) {
+        cancelRef.fn();
+      } else {
+        // Mark as cancelled so the .then() above will immediately unregister
+        cancelRef.fn = () => {};
+      }
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -300,11 +386,11 @@ function App() {
       className="h-screen overflow-hidden"
       style={{ "--sidebar-width": `${sidebarWidth}px` } as React.CSSProperties}
     >
-      {manifest && (
+      {activeTab && (
         <Sidebar collapsible="offcanvas">
           <PageSidebar
-            docId={manifest.doc_id}
-            pageSizes={manifest.page_sizes}
+            docId={activeTab.docId}
+            pageSizes={activeTab.pageSizes}
             onScrollToPage={(i) => viewerRef.current?.scrollToPage(i)}
             onBugReport={openBugReportForError}
           />
@@ -315,10 +401,10 @@ function App() {
         <Toolbar
           onOpen={handleOpen}
           loading={loading}
-          hasDocument={manifest !== null}
+          hasDocument={activeTab !== null}
           isDirty={isDirty}
-          canUndo={manifest?.can_undo ?? false}
-          canRedo={manifest?.can_redo ?? false}
+          canUndo={activeTab?.canUndo ?? false}
+          canRedo={activeTab?.canRedo ?? false}
           onSave={handleSave}
           onUndo={handleUndo}
           onRedo={handleRedo}
@@ -326,27 +412,41 @@ function App() {
           onToggleInfo={toggleInfoPanel}
         />
 
+        {tabs.length > 0 && (
+          <TabBar
+            tabs={tabs}
+            activeDocId={activeDocId}
+            onSwitch={handleSwitchTab}
+            onClose={(docId) => void handleCloseTab(docId)}
+            onReorder={reorderTabs}
+          />
+        )}
+
         <Separator />
 
-        <div className="flex-1 overflow-hidden min-h-0">
-          {manifest ? (
+        <div className="relative flex-1 overflow-hidden min-h-0">
+          {activeTab ? (
             <PageViewer
+              key={activeDocId}
               ref={viewerRef}
-              docId={manifest.doc_id}
-              pageSizes={manifest.page_sizes}
+              docId={activeTab.docId}
+              pageSizes={activeTab.pageSizes}
             />
           ) : (
             <EmptyState onOpen={handleOpen} />
           )}
+          {isDragOver && (
+            <div className="absolute inset-0 ring-2 ring-blue-500 ring-inset bg-blue-500/10 pointer-events-none" />
+          )}
         </div>
 
-        <StatusBar pageCount={manifest?.page_count} />
+        <StatusBar pageCount={activeTab?.pageCount} />
       </SidebarInset>
 
-      {manifest && (
+      {activeTab && (
         <InfoPanel
-          docId={manifest.doc_id}
-          filename={manifest.filename}
+          docId={activeTab.docId}
+          filename={activeTab.filename}
           open={infoPanelOpen}
           onOpenChange={setInfoPanelOpen}
         />

--- a/src/components/PageViewer.test.tsx
+++ b/src/components/PageViewer.test.tsx
@@ -112,6 +112,21 @@ describe("PageViewer — scrollToPage", () => {
 
     expect(useAppStore.getState().activePage).toBe(10); // page 11, NOT page 13 (index 12)
   });
+
+  it("scrollToPage sets scrollTop at the page's top edge including PAGE_TOP_GAP offset", async () => {
+    // At 75% zoom: pageWidth = round(612*75/100) = 459, rendered_h = round(792/612*459) = 594, slot = 610.
+    // Page 1 top in DOM = PAGE_TOP_GAP + slot0 = 16 + 610 = 626.
+    // scrollToPage(1) must set scrollTop = 626 so the page aligns to the viewport top.
+    const ref = createRef<PageViewerHandle>();
+    const { container } = render(<PageViewer ref={ref} docId={1} pageSizes={PAGES_5} />);
+    const scrollEl = container.firstElementChild as HTMLDivElement;
+
+    await act(async () => {
+      ref.current?.scrollToPage(1);
+    });
+
+    expect(scrollEl.scrollTop).toBe(626);
+  });
 });
 
 describe("PageViewer — natural scroll active page detection", () => {

--- a/src/components/PageViewer.tsx
+++ b/src/components/PageViewer.tsx
@@ -193,7 +193,7 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
       scrollToPage(index) {
         const el = parentRef.current;
         if (!el) return;
-        let offset = 0;
+        let offset = PAGE_TOP_GAP;
         for (let i = 0; i < index; i++) {
           const { width_pts, height_pts } = pageSizes[i];
           offset += Math.round((height_pts / width_pts) * pageWidthFor(width_pts)) + PAGE_GAP;

--- a/src/components/PageViewer.tsx
+++ b/src/components/PageViewer.tsx
@@ -21,6 +21,9 @@ export interface PageViewerHandle {
 /** Gap between pages in pixels. */
 const PAGE_GAP = 16;
 
+/** Extra space above the first page so content isn't cramped against the tab bar. */
+const PAGE_TOP_GAP = 28;
+
 /** Horizontal padding around pages in fit-width mode (16px each side). */
 const PAGE_PADDING_X = 32;
 
@@ -190,7 +193,7 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
       scrollToPage(index) {
         const el = parentRef.current;
         if (!el) return;
-        let offset = PAGE_GAP;
+        let offset = PAGE_TOP_GAP;
         for (let i = 0; i < index; i++) {
           const { width_pts, height_pts } = pageSizes[i];
           offset += Math.round((height_pts / width_pts) * pageWidthFor(width_pts)) + PAGE_GAP;
@@ -279,7 +282,7 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
       <div
         ref={parentRef}
         className={cn(
-          "h-full bg-zinc-200 dark:bg-zinc-800",
+          "h-full bg-muted",
           zoomMode === "fit-width" ? "overflow-y-auto" : "overflow-auto"
         )}
       >
@@ -287,7 +290,7 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
         <div
           className="relative w-full"
           style={{
-            height: virtualizer.getTotalSize() + PAGE_GAP,
+            height: virtualizer.getTotalSize() + PAGE_TOP_GAP,
             minWidth: manualContentWidth,
           }}
         >
@@ -305,7 +308,7 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
               <div
                 key={item.key}
                 className="absolute left-0 right-0"
-                style={{ top: item.start + PAGE_GAP, paddingBottom: PAGE_GAP }}
+                style={{ top: item.start + PAGE_TOP_GAP, paddingBottom: PAGE_GAP }}
               >
                 {/* mx-auto centers the page when it's narrower than the viewport. */}
                 <div style={{ width: pageWidth, margin: "0 auto" }}>

--- a/src/components/PageViewer.tsx
+++ b/src/components/PageViewer.tsx
@@ -21,8 +21,8 @@ export interface PageViewerHandle {
 /** Gap between pages in pixels. */
 const PAGE_GAP = 16;
 
-/** Extra space above the first page so content isn't cramped against the tab bar. */
-const PAGE_TOP_GAP = 28;
+/** Extra space above the first page — matches PAGE_GAP for visual consistency. */
+const PAGE_TOP_GAP = PAGE_GAP;
 
 /** Horizontal padding around pages in fit-width mode (16px each side). */
 const PAGE_PADDING_X = 32;
@@ -193,7 +193,7 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
       scrollToPage(index) {
         const el = parentRef.current;
         if (!el) return;
-        let offset = PAGE_TOP_GAP;
+        let offset = 0;
         for (let i = 0; i < index; i++) {
           const { width_pts, height_pts } = pageSizes[i];
           offset += Math.round((height_pts / width_pts) * pageWidthFor(width_pts)) + PAGE_GAP;

--- a/src/components/ShortcutOverlay.tsx
+++ b/src/components/ShortcutOverlay.tsx
@@ -4,7 +4,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { modKey, shiftModKey } from "@/lib/platform";
+import { isMac, modKey, shiftModKey } from "@/lib/platform";
 
 interface Props {
   open: boolean;
@@ -42,6 +42,23 @@ function buildSections(): Section[] {
         { action: "Zoom Out",       keys: [`${mod}−`] },
         { action: "Fit Width",      keys: [`${mod}0`] },
         { action: "Toggle Sidebar", keys: [`${mod}B`] },
+      ],
+    },
+    {
+      label: "Navigation",
+      rows: [
+        {
+          action: "Next Tab",
+          keys: isMac ? ["⌘⇧]"] : ["Ctrl+Tab", "Ctrl+PgDn"],
+        },
+        {
+          action: "Previous Tab",
+          keys: isMac ? ["⌘⇧["] : ["Ctrl+Shift+Tab", "Ctrl+PgUp"],
+        },
+        {
+          action: "Jump to Tab",
+          keys: [`${mod}1 – ${mod}9`],
+        },
       ],
     },
     {

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -1,0 +1,198 @@
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { TabBar } from "./TabBar";
+import type { TabEntry } from "@/store";
+import type { DragEndEvent } from "@dnd-kit/core";
+
+// Capture the onDragEnd handler so tests can invoke it directly
+let capturedOnDragEnd: ((event: DragEndEvent) => void) | undefined;
+
+vi.mock("@dnd-kit/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@dnd-kit/core")>();
+  return {
+    ...actual,
+    DndContext: ({
+      children,
+      onDragEnd,
+    }: {
+      children: React.ReactNode;
+      onDragEnd?: (event: DragEndEvent) => void;
+    }) => {
+      capturedOnDragEnd = onDragEnd;
+      return <>{children}</>;
+    },
+  };
+});
+
+const TAB_A: TabEntry = {
+  docId: 1,
+  filename: "alpha.pdf",
+  path: "/alpha.pdf",
+  pageCount: 2,
+  pageSizes: [],
+  canUndo: false,
+  canRedo: false,
+  isDirty: false,
+};
+
+const TAB_B: TabEntry = {
+  docId: 2,
+  filename: "beta.pdf",
+  path: "/beta.pdf",
+  pageCount: 5,
+  pageSizes: [],
+  canUndo: false,
+  canRedo: false,
+  isDirty: false,
+};
+
+describe("TabBar", () => {
+  it("renders a tab for each entry", () => {
+    render(
+      <TabBar tabs={[TAB_A, TAB_B]} activeDocId={1} onSwitch={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(screen.getByText("alpha.pdf")).toBeInTheDocument();
+    expect(screen.getByText("beta.pdf")).toBeInTheDocument();
+  });
+
+  it("marks only the active tab with aria-selected=true", () => {
+    render(
+      <TabBar tabs={[TAB_A, TAB_B]} activeDocId={1} onSwitch={vi.fn()} onClose={vi.fn()} />
+    );
+    const tabs = screen.getAllByRole("tab");
+    const alphaTab = tabs.find((t) => t.textContent?.includes("alpha.pdf"))!;
+    const betaTab = tabs.find((t) => t.textContent?.includes("beta.pdf"))!;
+    expect(alphaTab).toHaveAttribute("aria-selected", "true");
+    expect(betaTab).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("calls onSwitch with the correct docId when a tab body is clicked", async () => {
+    const onSwitch = vi.fn();
+    render(
+      <TabBar tabs={[TAB_A, TAB_B]} activeDocId={1} onSwitch={onSwitch} onClose={vi.fn()} />
+    );
+    await userEvent.click(screen.getByText("beta.pdf"));
+    expect(onSwitch).toHaveBeenCalledWith(2);
+  });
+
+  it("calls onClose with the correct docId when the close button is clicked", async () => {
+    const onClose = vi.fn();
+    render(
+      <TabBar tabs={[TAB_A, TAB_B]} activeDocId={1} onSwitch={vi.fn()} onClose={onClose} />
+    );
+    await userEvent.click(screen.getByRole("button", { name: /close beta\.pdf/i }));
+    expect(onClose).toHaveBeenCalledWith(2);
+  });
+
+  it("close button click does not also fire onSwitch", async () => {
+    const onSwitch = vi.fn();
+    render(
+      <TabBar tabs={[TAB_A, TAB_B]} activeDocId={1} onSwitch={onSwitch} onClose={vi.fn()} />
+    );
+    await userEvent.click(screen.getByRole("button", { name: /close beta\.pdf/i }));
+    expect(onSwitch).not.toHaveBeenCalled();
+  });
+
+  it("renders dirty dot when tab.isDirty is true", () => {
+    const dirtyTab = { ...TAB_A, isDirty: true };
+    render(
+      <TabBar tabs={[dirtyTab]} activeDocId={1} onSwitch={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(screen.getByLabelText("unsaved changes")).toBeInTheDocument();
+  });
+
+  it("does not render dirty dot when tab.isDirty is false", () => {
+    render(
+      <TabBar tabs={[TAB_A]} activeDocId={1} onSwitch={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(screen.queryByLabelText("unsaved changes")).not.toBeInTheDocument();
+  });
+
+  it("close button has accessible label including filename", () => {
+    render(
+      <TabBar tabs={[TAB_A]} activeDocId={1} onSwitch={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(screen.getByRole("button", { name: /close alpha\.pdf/i })).toBeInTheDocument();
+  });
+
+  it("middle-truncates filenames longer than 24 characters", () => {
+    const longTab = { ...TAB_A, filename: "very-long-document-name-here.pdf" };
+    render(
+      <TabBar tabs={[longTab]} activeDocId={1} onSwitch={vi.fn()} onClose={vi.fn()} />
+    );
+    const displayed = screen.getByTitle("very-long-document-name-here.pdf").textContent!;
+    expect(displayed.length).toBeLessThanOrEqual(24);
+    expect(displayed).toContain("…");
+    expect(displayed.endsWith(".pdf")).toBe(true);
+  });
+
+  it("renders nothing when tabs array is empty", () => {
+    const { container } = render(
+      <TabBar tabs={[]} activeDocId={null} onSwitch={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  describe("tab reordering", () => {
+    it("calls onReorder with correct indices when drag ends on a different tab", () => {
+      const onReorder = vi.fn();
+      render(
+        <TabBar
+          tabs={[TAB_A, TAB_B]}
+          activeDocId={1}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onReorder={onReorder}
+        />
+      );
+      act(() => {
+        capturedOnDragEnd?.({
+          active: { id: TAB_A.docId },
+          over: { id: TAB_B.docId },
+        } as DragEndEvent);
+      });
+      expect(onReorder).toHaveBeenCalledWith(0, 1);
+    });
+
+    it("does not call onReorder when dropped on the same tab", () => {
+      const onReorder = vi.fn();
+      render(
+        <TabBar
+          tabs={[TAB_A, TAB_B]}
+          activeDocId={1}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onReorder={onReorder}
+        />
+      );
+      act(() => {
+        capturedOnDragEnd?.({
+          active: { id: TAB_A.docId },
+          over: { id: TAB_A.docId },
+        } as DragEndEvent);
+      });
+      expect(onReorder).not.toHaveBeenCalled();
+    });
+
+    it("does not call onReorder when dropped outside any tab", () => {
+      const onReorder = vi.fn();
+      render(
+        <TabBar
+          tabs={[TAB_A, TAB_B]}
+          activeDocId={1}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onReorder={onReorder}
+        />
+      );
+      act(() => {
+        capturedOnDragEnd?.({
+          active: { id: TAB_A.docId },
+          over: null,
+        } as DragEndEvent);
+      });
+      expect(onReorder).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,0 +1,117 @@
+import { X } from "lucide-react";
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  horizontalListSortingStrategy,
+  useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { cn } from "@/lib/utils";
+import { middleTruncate } from "@/lib/truncate";
+import type { TabEntry } from "@/store";
+
+interface TabBarProps {
+  tabs: TabEntry[];
+  activeDocId: number | null;
+  onSwitch(docId: number): void;
+  onClose(docId: number): void;
+  onReorder?: (fromIndex: number, toIndex: number) => void;
+}
+
+interface SortableTabProps {
+  tab: TabEntry;
+  isActive: boolean;
+  onSwitch(docId: number): void;
+  onClose(docId: number): void;
+}
+
+function SortableTab({ tab, isActive, onSwitch, onClose }: SortableTabProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: tab.docId });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : undefined,
+  };
+
+  return (
+    <button
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      role="tab"
+      aria-selected={isActive}
+      tabIndex={isActive ? 0 : -1}
+      onClick={() => onSwitch(tab.docId)}
+      className={cn(
+        "flex items-center gap-1.5 px-3 h-full text-sm whitespace-nowrap border-r border-border/50 select-none cursor-grab active:cursor-grabbing",
+        isActive
+          ? "bg-background text-foreground border-b-2 border-b-primary -mb-px"
+          : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+      )}
+    >
+      {tab.isDirty && (
+        <span aria-label="unsaved changes" className="size-1.5 rounded-full bg-amber-400 shrink-0" />
+      )}
+      <span title={tab.filename}>{middleTruncate(tab.filename, 24)}</span>
+      <button
+        type="button"
+        aria-label={`Close ${tab.filename}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClose(tab.docId);
+        }}
+        className="ml-0.5 rounded-sm p-0.5 hover:bg-muted-foreground/20 shrink-0"
+      >
+        <X className="size-3" />
+      </button>
+    </button>
+  );
+}
+
+export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabBarProps) {
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
+
+  if (tabs.length === 0) return null;
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const fromIndex = tabs.findIndex((t) => t.docId === active.id);
+    const toIndex = tabs.findIndex((t) => t.docId === over.id);
+    if (fromIndex !== -1 && toIndex !== -1) {
+      onReorder?.(fromIndex, toIndex);
+    }
+  }
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={tabs.map((t) => t.docId)} strategy={horizontalListSortingStrategy}>
+        <div
+          role="tablist"
+          aria-label="Open documents"
+          className="flex h-8 shrink-0 overflow-x-auto border-b bg-muted/30"
+        >
+          {tabs.map((tab) => (
+            <SortableTab
+              key={tab.docId}
+              tab={tab}
+              isActive={tab.docId === activeDocId}
+              onSwitch={onSwitch}
+              onClose={onClose}
+            />
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -10,7 +10,7 @@ import {
   type DragEndEvent,
   type DragStartEvent,
 } from "@dnd-kit/core";
-import { restrictToHorizontalAxis } from "@dnd-kit/modifiers";
+import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
 import {
   SortableContext,
   horizontalListSortingStrategy,
@@ -59,17 +59,23 @@ function SortableTab({ tab, isActive, onSwitch, onClose }: SortableTabProps) {
   };
 
   return (
-    <button
+    <div
       ref={setNodeRef}
       style={style}
       {...attributes}
       {...listeners}
       role="tab"
       aria-selected={isActive}
-      tabIndex={isActive ? 0 : -1}
+      tabIndex={0}
       onClick={() => onSwitch(tab.docId)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSwitch(tab.docId);
+        }
+      }}
       className={cn(
-        "inline-flex items-center gap-1.5 px-3 h-7 text-sm font-medium whitespace-nowrap border-t-2 select-none cursor-grab active:cursor-grabbing transition-colors",
+        "inline-flex items-center gap-1.5 px-3.5 h-8 text-sm font-medium whitespace-nowrap border-t-2 select-none cursor-grab active:cursor-grabbing transition-colors",
         isDragging && "opacity-0",
         isActive
           ? "bg-muted text-foreground border-primary"
@@ -80,15 +86,16 @@ function SortableTab({ tab, isActive, onSwitch, onClose }: SortableTabProps) {
       <button
         type="button"
         aria-label={`Close ${tab.filename}`}
+        onPointerDown={(e) => e.stopPropagation()}
         onClick={(e) => {
           e.stopPropagation();
           onClose(tab.docId);
         }}
-        className="ml-0.5 rounded-sm p-0.5 hover:bg-muted-foreground/20 shrink-0"
+        className="ml-0.5 rounded-sm p-0.5 hover:bg-muted-foreground/30 shrink-0 cursor-default"
       >
         <X className="size-3" />
       </button>
-    </button>
+    </div>
   );
 }
 
@@ -123,7 +130,7 @@ export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabB
     <DndContext
       sensors={sensors}
       collisionDetection={closestCenter}
-      modifiers={[restrictToHorizontalAxis]}
+      modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
@@ -132,7 +139,7 @@ export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabB
         <div
           role="tablist"
           aria-label="Open documents"
-          className="flex shrink-0 overflow-x-auto items-end bg-background pt-1 px-2 gap-[3px]"
+          className="flex shrink-0 overflow-x-auto items-end bg-background border-t border-border pt-1.5 px-2 gap-1"
         >
           {tabs.map((tab) => (
             <SortableTab
@@ -148,7 +155,7 @@ export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabB
 
       <DragOverlay dropAnimation={null}>
         {activeTab && (
-          <div className="inline-flex items-center gap-1.5 px-3 h-7 text-sm font-medium whitespace-nowrap border-t-2 bg-tab-inactive text-muted-foreground border-transparent cursor-grabbing shadow-md">
+          <div className="inline-flex items-center gap-1.5 px-3.5 h-8 text-sm font-medium whitespace-nowrap border-t-2 bg-muted text-foreground border-primary cursor-grabbing shadow-lg">
             <TabContent tab={activeTab} />
             <span className="ml-0.5 p-0.5">
               <X className="size-3" />

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,12 +1,16 @@
+import { useState } from "react";
 import { X } from "lucide-react";
 import {
   DndContext,
+  DragOverlay,
   PointerSensor,
   useSensor,
   useSensors,
   closestCenter,
   type DragEndEvent,
+  type DragStartEvent,
 } from "@dnd-kit/core";
+import { restrictToHorizontalAxis } from "@dnd-kit/modifiers";
 import {
   SortableContext,
   horizontalListSortingStrategy,
@@ -32,14 +36,26 @@ interface SortableTabProps {
   onClose(docId: number): void;
 }
 
+/** Shared tab content — rendered both in SortableTab and DragOverlay. */
+function TabContent({ tab }: { tab: TabEntry }) {
+  return (
+    <>
+      {tab.isDirty && (
+        <span aria-label="unsaved changes" className="size-1.5 rounded-full bg-amber-400 shrink-0" />
+      )}
+      <span title={tab.filename}>{middleTruncate(tab.filename, 24)}</span>
+      {/* Close button is rendered separately in SortableTab; omitted here intentionally */}
+    </>
+  );
+}
+
 function SortableTab({ tab, isActive, onSwitch, onClose }: SortableTabProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: tab.docId });
 
   const style = {
-    transform: CSS.Transform.toString(transform),
+    transform: CSS.Translate.toString(transform),
     transition,
-    opacity: isDragging ? 0.5 : undefined,
   };
 
   return (
@@ -53,16 +69,14 @@ function SortableTab({ tab, isActive, onSwitch, onClose }: SortableTabProps) {
       tabIndex={isActive ? 0 : -1}
       onClick={() => onSwitch(tab.docId)}
       className={cn(
-        "flex items-center gap-1.5 px-3 h-full text-sm whitespace-nowrap border-r border-border/50 select-none cursor-grab active:cursor-grabbing",
+        "inline-flex items-center gap-1.5 px-3 h-7 text-sm font-medium whitespace-nowrap border-t-2 select-none cursor-grab active:cursor-grabbing transition-colors",
+        isDragging && "opacity-0",
         isActive
-          ? "bg-background text-foreground border-b-2 border-b-primary -mb-px"
-          : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+          ? "bg-muted text-foreground border-primary"
+          : "bg-tab-inactive text-muted-foreground border-transparent hover:bg-muted hover:text-foreground"
       )}
     >
-      {tab.isDirty && (
-        <span aria-label="unsaved changes" className="size-1.5 rounded-full bg-amber-400 shrink-0" />
-      )}
-      <span title={tab.filename}>{middleTruncate(tab.filename, 24)}</span>
+      <TabContent tab={tab} />
       <button
         type="button"
         aria-label={`Close ${tab.filename}`}
@@ -79,11 +93,19 @@ function SortableTab({ tab, isActive, onSwitch, onClose }: SortableTabProps) {
 }
 
 export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabBarProps) {
+  const [activeId, setActiveId] = useState<number | null>(null);
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
 
   if (tabs.length === 0) return null;
 
+  const activeTab = activeId !== null ? tabs.find((t) => t.docId === activeId) : null;
+
+  function handleDragStart(event: DragStartEvent) {
+    setActiveId(event.active.id as number);
+  }
+
   function handleDragEnd(event: DragEndEvent) {
+    setActiveId(null);
     const { active, over } = event;
     if (!over || active.id === over.id) return;
     const fromIndex = tabs.findIndex((t) => t.docId === active.id);
@@ -93,13 +115,24 @@ export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabB
     }
   }
 
+  function handleDragCancel() {
+    setActiveId(null);
+  }
+
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      modifiers={[restrictToHorizontalAxis]}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
       <SortableContext items={tabs.map((t) => t.docId)} strategy={horizontalListSortingStrategy}>
         <div
           role="tablist"
           aria-label="Open documents"
-          className="flex h-8 shrink-0 overflow-x-auto border-b bg-muted/30"
+          className="flex shrink-0 overflow-x-auto items-end bg-background pt-1 px-2 gap-[3px]"
         >
           {tabs.map((tab) => (
             <SortableTab
@@ -112,6 +145,17 @@ export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabB
           ))}
         </div>
       </SortableContext>
+
+      <DragOverlay dropAnimation={null}>
+        {activeTab && (
+          <div className="inline-flex items-center gap-1.5 px-3 h-7 text-sm font-medium whitespace-nowrap border-t-2 bg-tab-inactive text-muted-foreground border-transparent cursor-grabbing shadow-md">
+            <TabContent tab={activeTab} />
+            <span className="ml-0.5 p-0.5">
+              <X className="size-3" />
+            </span>
+          </div>
+        )}
+      </DragOverlay>
     </DndContext>
   );
 }

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -25,6 +25,23 @@ describe("isDirty", () => {
     useAppStore.getState().setIsDirty(false);
     expect(useAppStore.getState().isDirty).toBe(false);
   });
+
+  it("setIsDirty(true) also marks the active tab's isDirty in the tabs array", () => {
+    useAppStore.setState({ tabs: [], activeDocId: null, docViewStates: new Map() });
+    useAppStore.getState().addTab(MANIFEST_A);
+    useAppStore.getState().setIsDirty(true);
+    const tab = useAppStore.getState().tabs.find((t) => t.docId === 1);
+    expect(tab?.isDirty).toBe(true);
+  });
+
+  it("setIsDirty(false) also clears the active tab's isDirty in the tabs array", () => {
+    useAppStore.setState({ tabs: [], activeDocId: null, docViewStates: new Map() });
+    useAppStore.getState().addTab(MANIFEST_A);
+    useAppStore.getState().setIsDirty(true);
+    useAppStore.getState().setIsDirty(false);
+    const tab = useAppStore.getState().tabs.find((t) => t.docId === 1);
+    expect(tab?.isDirty).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { useAppStore } from "@/store";
+import { useAppStore, DEFAULT_DOC_VIEW_STATE } from "@/store";
+import type { DocumentManifest } from "@/types";
 
 beforeEach(() => {
   useAppStore.setState({ isDirty: false, selectedPages: new Set() });
@@ -142,6 +143,235 @@ describe("recentFiles", () => {
     useAppStore.setState({ recentFiles: ["/a.pdf"] });
     useAppStore.getState().clearRecentFiles();
     expect(useAppStore.getState().recentFiles).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tab management
+// ---------------------------------------------------------------------------
+
+const MANIFEST_A: DocumentManifest = {
+  doc_id: 1,
+  filename: "a.pdf",
+  path: "/a.pdf",
+  page_count: 2,
+  page_sizes: [],
+  can_undo: false,
+  can_redo: false,
+};
+
+const MANIFEST_B: DocumentManifest = {
+  doc_id: 2,
+  filename: "b.pdf",
+  path: "/b.pdf",
+  page_count: 3,
+  page_sizes: [],
+  can_undo: false,
+  can_redo: false,
+};
+
+const MANIFEST_C: DocumentManifest = {
+  doc_id: 3,
+  filename: "c.pdf",
+  path: "/c.pdf",
+  page_count: 1,
+  page_sizes: [],
+  can_undo: false,
+  can_redo: false,
+};
+
+describe("tab management", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      tabs: [],
+      activeDocId: null,
+      docViewStates: new Map(),
+      activePage: 0,
+      zoom: 75,
+      zoomMode: "manual",
+      selectedPages: new Set(),
+      isDirty: false,
+    });
+  });
+
+  describe("addTab", () => {
+    it("sets activeDocId to the new doc", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      expect(useAppStore.getState().activeDocId).toBe(1);
+    });
+
+    it("appends a TabEntry to tabs", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      const { tabs } = useAppStore.getState();
+      expect(tabs).toHaveLength(1);
+      expect(tabs[0].docId).toBe(1);
+      expect(tabs[0].filename).toBe("a.pdf");
+      expect(tabs[0].pageCount).toBe(2);
+    });
+
+    it("initializes docViewState for the new doc", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      const state = useAppStore.getState().docViewStates.get(1);
+      expect(state).toBeDefined();
+      expect(state?.zoom).toBe(DEFAULT_DOC_VIEW_STATE.zoom);
+    });
+
+    it("resets top-level view state to defaults", () => {
+      useAppStore.setState({ zoom: 200, activePage: 5, isDirty: true });
+      useAppStore.getState().addTab(MANIFEST_A);
+      const s = useAppStore.getState();
+      expect(s.activePage).toBe(0);
+      expect(s.zoom).toBe(75);
+      expect(s.isDirty).toBe(false);
+    });
+
+    it("saves previous active doc's state before switching", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.setState({ zoom: 150, activePage: 3 });
+      useAppStore.getState().addTab(MANIFEST_B);
+      // A's state should have been saved
+      const aState = useAppStore.getState().docViewStates.get(1);
+      expect(aState?.zoom).toBe(150);
+      expect(aState?.activePage).toBe(3);
+    });
+
+    it("opening two tabs gives two entries", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      expect(useAppStore.getState().tabs).toHaveLength(2);
+      expect(useAppStore.getState().activeDocId).toBe(2);
+    });
+  });
+
+  describe("removeTab", () => {
+    it("removes the tab from tabs and docViewStates", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().removeTab(1);
+      expect(useAppStore.getState().tabs).toHaveLength(0);
+      expect(useAppStore.getState().docViewStates.has(1)).toBe(false);
+    });
+
+    it("sets activeDocId to null when last tab is closed", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().removeTab(1);
+      expect(useAppStore.getState().activeDocId).toBeNull();
+    });
+
+    it("switches to left neighbour when active tab is closed", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      // B is active; close B → should go to A
+      useAppStore.getState().removeTab(2);
+      expect(useAppStore.getState().activeDocId).toBe(1);
+      expect(useAppStore.getState().tabs).toHaveLength(1);
+    });
+
+    it("switches to first tab when leftmost active tab is closed with others present", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      useAppStore.getState().addTab(MANIFEST_C);
+      // manually make A active (leftmost)
+      useAppStore.getState().setActiveDocId(1);
+      useAppStore.getState().removeTab(1);
+      // Should fall through to B (now first)
+      expect(useAppStore.getState().activeDocId).toBe(2);
+    });
+
+    it("closing a non-active tab does not change activeDocId", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      // B is active; close A
+      useAppStore.getState().removeTab(1);
+      expect(useAppStore.getState().activeDocId).toBe(2);
+      expect(useAppStore.getState().tabs).toHaveLength(1);
+    });
+  });
+
+  describe("setActiveDocId", () => {
+    it("saves current top-level state to the outgoing doc", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      useAppStore.setState({ zoom: 200, activePage: 7 });
+      // Switch away from B
+      useAppStore.getState().setActiveDocId(1);
+      expect(useAppStore.getState().docViewStates.get(2)?.zoom).toBe(200);
+      expect(useAppStore.getState().docViewStates.get(2)?.activePage).toBe(7);
+    });
+
+    it("restores the target doc's saved state into top-level fields", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      // After both tabs are open, override A's saved state
+      useAppStore.setState({
+        docViewStates: new Map([
+          [1, { ...DEFAULT_DOC_VIEW_STATE, zoom: 150, activePage: 4 }],
+          [2, { ...DEFAULT_DOC_VIEW_STATE }],
+        ]),
+      });
+      useAppStore.getState().setActiveDocId(1);
+      expect(useAppStore.getState().zoom).toBe(150);
+      expect(useAppStore.getState().activePage).toBe(4);
+    });
+
+    it("updates activeDocId", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      useAppStore.getState().setActiveDocId(1);
+      expect(useAppStore.getState().activeDocId).toBe(1);
+    });
+  });
+
+  describe("reorderTabs", () => {
+    it("moves a tab from one index to another", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      useAppStore.getState().addTab(MANIFEST_C);
+      useAppStore.getState().reorderTabs(0, 2);
+      const ids = useAppStore.getState().tabs.map((t) => t.docId);
+      expect(ids).toEqual([2, 3, 1]);
+    });
+
+    it("moves a tab from last to first", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      useAppStore.getState().addTab(MANIFEST_C);
+      useAppStore.getState().reorderTabs(2, 0);
+      const ids = useAppStore.getState().tabs.map((t) => t.docId);
+      expect(ids).toEqual([3, 1, 2]);
+    });
+
+    it("does not change activeDocId", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      useAppStore.getState().reorderTabs(0, 1);
+      expect(useAppStore.getState().activeDocId).toBe(2);
+    });
+
+    it("is a no-op when fromIndex === toIndex", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      useAppStore.getState().reorderTabs(1, 1);
+      const ids = useAppStore.getState().tabs.map((t) => t.docId);
+      expect(ids).toEqual([1, 2]);
+    });
+  });
+
+  describe("per-doc state isolation", () => {
+    it("setZoom on active doc does not affect inactive doc's saved state", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      // Save A's state at zoom=100
+      useAppStore.setState({
+        docViewStates: new Map([
+          [1, { ...DEFAULT_DOC_VIEW_STATE, zoom: 100 }],
+          [2, { ...DEFAULT_DOC_VIEW_STATE, zoom: 75 }],
+        ]),
+      });
+      // Change active (B) zoom
+      useAppStore.getState().setZoom(300);
+      // A's saved state unchanged
+      expect(useAppStore.getState().docViewStates.get(1)?.zoom).toBe(100);
+    });
   });
 });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -190,7 +190,16 @@ export const useAppStore = create<AppStore>()(
       zoomMode: "manual",
       setZoomMode: (zoomMode) => set({ zoomMode }),
       isDirty: false,
-      setIsDirty: (dirty) => set({ isDirty: dirty }),
+      setIsDirty: (dirty) =>
+        set((s) => ({
+          isDirty: dirty,
+          tabs:
+            s.activeDocId !== null
+              ? s.tabs.map((t) =>
+                  t.docId === s.activeDocId ? { ...t, isDirty: dirty } : t
+                )
+              : s.tabs,
+        })),
       selectedPages: new Set<number>(),
       togglePageSelection: (index) =>
         set((s) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,26 +1,56 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import type { DocumentManifest, PageSize } from "@/types";
 
+export type { PageSize };
 export type Theme = "light" | "dark" | "system";
 export type ZoomMode = "fit-width" | "manual";
 export type PageDisplay = "continuous" | "single" | "spread";
 
+export interface DocViewState {
+  activePage: number;
+  zoom: number;
+  zoomMode: ZoomMode;
+  selectedPages: ReadonlySet<number>;
+  isDirty: boolean;
+}
+
+export const DEFAULT_DOC_VIEW_STATE: DocViewState = {
+  activePage: 0,
+  zoom: 75,
+  zoomMode: "manual",
+  selectedPages: new Set(),
+  isDirty: false,
+};
+
+export interface TabEntry {
+  docId: number;
+  filename: string;
+  path: string;
+  pageCount: number;
+  pageSizes: PageSize[];
+  canUndo: boolean;
+  canRedo: boolean;
+  isDirty: boolean;
+}
+
 interface AppStore {
+  // Tab management
+  tabs: TabEntry[];
+  activeDocId: number | null;
+  docViewStates: Map<number, DocViewState>;
+  addTab(manifest: DocumentManifest): void;
+  removeTab(docId: number): void;
+  setActiveDocId(docId: number): void;
+  reorderTabs(fromIndex: number, toIndex: number): void;
+
+  // Active doc view state (top-level live copy; saved/restored on tab switch)
   activePage: number;
   setActivePage(index: number): void;
-  sidebarWidth: number;
-  setSidebarWidth(width: number): void;
-  theme: Theme;
-  setTheme(theme: Theme): void;
-  recentFiles: string[];
-  addRecentFile(path: string): void;
-  clearRecentFiles(): void;
   zoom: number;
   setZoom(zoom: number): void;
   zoomMode: ZoomMode;
   setZoomMode(mode: ZoomMode): void;
-  pageDisplay: PageDisplay;
-  setPageDisplay(mode: PageDisplay): void;
   isDirty: boolean;
   setIsDirty(dirty: boolean): void;
   selectedPages: ReadonlySet<number>;
@@ -28,6 +58,17 @@ interface AppStore {
   selectPageRange(from: number, to: number): void;
   clearSelection(): void;
   selectAll(count: number): void;
+
+  // Persistent preferences
+  sidebarWidth: number;
+  setSidebarWidth(width: number): void;
+  theme: Theme;
+  setTheme(theme: Theme): void;
+  recentFiles: string[];
+  addRecentFile(path: string): void;
+  clearRecentFiles(): void;
+  pageDisplay: PageDisplay;
+  setPageDisplay(mode: PageDisplay): void;
   infoPanelOpen: boolean;
   setInfoPanelOpen(open: boolean): void;
   toggleInfoPanel(): void;
@@ -35,28 +76,119 @@ interface AppStore {
 
 export const ZOOM_STEPS = [25, 50, 75, 100, 125, 150, 200, 300, 400];
 
+/** Snapshot the current top-level view state fields into a DocViewState object. */
+function captureViewState(s: AppStore): DocViewState {
+  return {
+    activePage: s.activePage,
+    zoom: s.zoom,
+    zoomMode: s.zoomMode,
+    selectedPages: s.selectedPages,
+    isDirty: s.isDirty,
+  };
+}
+
 export const useAppStore = create<AppStore>()(
   persist(
-    (set) => ({
+    (set, get) => ({
+      // Tab management
+      tabs: [],
+      activeDocId: null,
+      docViewStates: new Map(),
+
+      addTab: (manifest) =>
+        set((s) => {
+          const saved = new Map(s.docViewStates);
+          // Save current active doc's state before switching
+          if (s.activeDocId !== null) {
+            saved.set(s.activeDocId, captureViewState(s));
+          }
+          // Initialize new doc's state
+          saved.set(manifest.doc_id, { ...DEFAULT_DOC_VIEW_STATE });
+          const newTab: TabEntry = {
+            docId: manifest.doc_id,
+            filename: manifest.filename,
+            path: manifest.path,
+            pageCount: manifest.page_count,
+            pageSizes: manifest.page_sizes,
+            canUndo: manifest.can_undo,
+            canRedo: manifest.can_redo,
+            isDirty: false,
+          };
+          return {
+            tabs: [...s.tabs, newTab],
+            activeDocId: manifest.doc_id,
+            docViewStates: saved,
+            // Reset top-level live state for the new doc
+            ...DEFAULT_DOC_VIEW_STATE,
+          };
+        }),
+
+      removeTab: (docId) =>
+        set((s) => {
+          const idx = s.tabs.findIndex((t) => t.docId === docId);
+          if (idx === -1) return {};
+          const nextTabs = s.tabs.filter((t) => t.docId !== docId);
+          const nextStates = new Map(s.docViewStates);
+          nextStates.delete(docId);
+
+          // Determine next active doc
+          let nextActiveId: number | null = s.activeDocId;
+          let liveOverride: Partial<DocViewState> = {};
+
+          if (s.activeDocId === docId) {
+            if (nextTabs.length === 0) {
+              nextActiveId = null;
+              liveOverride = { ...DEFAULT_DOC_VIEW_STATE };
+            } else {
+              // Pick left neighbour, falling back to the new first tab
+              const neighbourIdx = Math.max(0, idx - 1);
+              nextActiveId = nextTabs[neighbourIdx].docId;
+              const saved = nextStates.get(nextActiveId);
+              liveOverride = saved ? { ...saved } : { ...DEFAULT_DOC_VIEW_STATE };
+            }
+          }
+
+          return {
+            tabs: nextTabs,
+            activeDocId: nextActiveId,
+            docViewStates: nextStates,
+            ...liveOverride,
+          };
+        }),
+
+      reorderTabs: (fromIndex, toIndex) =>
+        set((s) => {
+          if (fromIndex === toIndex) return {};
+          const next = [...s.tabs];
+          const [moved] = next.splice(fromIndex, 1);
+          next.splice(toIndex, 0, moved);
+          return { tabs: next };
+        }),
+
+      setActiveDocId: (docId) =>
+        set((s) => {
+          if (s.activeDocId === docId) return {};
+          // Save current doc state
+          const saved = new Map(s.docViewStates);
+          if (s.activeDocId !== null) {
+            saved.set(s.activeDocId, captureViewState(s));
+          }
+          // Restore target doc state
+          const target = saved.get(docId) ?? DEFAULT_DOC_VIEW_STATE;
+          return {
+            activeDocId: docId,
+            docViewStates: saved,
+            ...target,
+          };
+        }),
+
+      // Active doc view state
       activePage: 0,
       setActivePage: (index) => set({ activePage: index }),
-      sidebarWidth: 160,
-      setSidebarWidth: (width) => set({ sidebarWidth: width }),
-      theme: "system",
-      setTheme: (theme) => set({ theme }),
-      recentFiles: [],
-      addRecentFile: (path) =>
-        set((s) => {
-          const without = s.recentFiles.filter((p) => p !== path);
-          return { recentFiles: [path, ...without].slice(0, 10) };
-        }),
-      clearRecentFiles: () => set({ recentFiles: [] }),
       zoom: 75,
       setZoom: (zoom) => set({ zoom }),
       zoomMode: "manual",
       setZoomMode: (zoomMode) => set({ zoomMode }),
-      pageDisplay: "continuous",
-      setPageDisplay: (pageDisplay) => set({ pageDisplay }),
       isDirty: false,
       setIsDirty: (dirty) => set({ isDirty: dirty }),
       selectedPages: new Set<number>(),
@@ -80,13 +212,28 @@ export const useAppStore = create<AppStore>()(
         for (let i = 0; i < count; i++) next.add(i);
         set({ selectedPages: next });
       },
+
+      // Persistent preferences
+      sidebarWidth: 160,
+      setSidebarWidth: (width) => set({ sidebarWidth: width }),
+      theme: "system",
+      setTheme: (theme) => set({ theme }),
+      recentFiles: [],
+      addRecentFile: (path) =>
+        set((s) => {
+          const without = s.recentFiles.filter((p) => p !== path);
+          return { recentFiles: [path, ...without].slice(0, 10) };
+        }),
+      clearRecentFiles: () => set({ recentFiles: [] }),
+      pageDisplay: "continuous",
+      setPageDisplay: (pageDisplay) => set({ pageDisplay }),
       infoPanelOpen: false,
       setInfoPanelOpen: (open) => set({ infoPanelOpen: open }),
       toggleInfoPanel: () => set((s) => ({ infoPanelOpen: !s.infoPanelOpen })),
     }),
     {
       name: "collate-settings",
-      // Only persist user preferences, not transient document state
+      // Only persist user preferences, not transient document/tab state
       partialize: (state) => ({ theme: state.theme, recentFiles: state.recentFiles }),
     }
   )

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,14 @@
+export interface PageSize {
+  width_pts: number;
+  height_pts: number;
+}
+
+export interface DocumentManifest {
+  doc_id: number;
+  page_count: number;
+  filename: string;
+  path: string;
+  page_sizes: PageSize[];
+  can_undo: boolean;
+  can_redo: boolean;
+}


### PR DESCRIPTION
## Summary

- Adds a `TabBar` component with drag-to-reorder support via `@dnd-kit/sortable`
- Improves drag UX: `DragOverlay` ghost tab, horizontal-axis constraint (`@dnd-kit/modifiers`), source tab hides while dragging
- Restyled tabs with top-border active indicator, per-tab inactive background token (`--tab-inactive`), and gap-based layout
- Adds `PAGE_TOP_GAP` so page content isn't cramped against the tab bar
- Locks `html/body` overflow to prevent scroll bleed during drag

## Test plan

- [ ] Open multiple PDFs and verify tabs appear
- [ ] Click tabs to switch active document
- [ ] Drag tabs to reorder — confirm ghost overlay follows cursor horizontally only
- [ ] Close a tab via the X button
- [ ] Verify active tab has top-border indicator; inactive tabs have distinct background
- [ ] Toggle dark mode — confirm `--tab-inactive` token applies correctly
- [ ] Scroll content area — confirm no page scroll bleed outside the viewer