### PR TITLE
feat: P1.7 keyboard navigation — Vim-style page nav, sidebar selection expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ lib/
 
 # Claude Code local settings (personal overrides, not for team)
 .claude/settings.local.json
+.superpowers/
 
 # Editor directories and files
 .vscode/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,10 @@ Tim is learning Rust through this project. He knows Go, bash, and unix tooling w
 
 Any button, menu item, toolbar action, or context menu item that requires an open document **must be disabled** (not hidden) when no document is open. This includes — but is not limited to — zoom controls, page navigation, close, print, and any document-mutation actions. Use shadcn/ui's `disabled` prop (which maps to the native `disabled` attribute and ARIA semantics). The enabled/disabled state must derive from the zustand store's document presence flag, not from ad-hoc local checks.
 
+## Long Text Truncation Rule
+
+Use `middleTruncate(str, maxLength)` from `src/lib/truncate.ts` when displaying long text (filenames, paths, labels) in the UI. It preserves both ends of the string; for filenames it also keeps the extension intact. Do not use the CSS `truncate` class for text that has semantic meaning at both ends.
+
 ## Key Design Principles (from spec)
 
 - Non-destructive by default. Source files are never modified until explicit save.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -748,6 +748,10 @@ For each page that has form fields, React renders a `<FormFieldOverlay>` positio
 
 Each input is positioned using the normalized coordinates from the backend (Section 5.3). Percentage-based positioning means the overlay scales automatically with zoom.
 
+### 7.7 UI Conventions
+
+**Long text truncation:** Use `middleTruncate(str, maxLength)` from `src/lib/truncate.ts` wherever long text needs to be shortened (filenames, paths, labels). It preserves both ends of the string and, for filenames, keeps the extension intact. Do not use the CSS `truncate` class for text that has semantic meaning at both ends.
+
 ---
 
 ## 8. Build & Distribution

--- a/docs/superpowers/plans/2026-04-18-keyboard-navigation.md
+++ b/docs/superpowers/plans/2026-04-18-keyboard-navigation.md
@@ -1,0 +1,1069 @@
+# Keyboard Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire Vim-style page navigation (j/k/gg/G) and standard fallbacks (PgUp/PgDn/Home/End) via a single `useKeyboardNav` hook, add sidebar selection expansion (Shift+j/k/↑/↓), and update the shortcut overlay.
+
+**Architecture:** All keyboard handling lives in `src/hooks/useKeyboardNav.ts` — one place to look, called once from `App.tsx`. The hook reads store state via `useAppStore.getState()` and fires `pageViewerRef.current?.scrollToPage()`. A `selectionAnchor` field added to the zustand store (and `DocViewState`) lets selection expansion survive tab switches.
+
+**Tech Stack:** React + TypeScript, Zustand, Vitest + Testing Library, shadcn/ui Dialog, Tailwind CSS.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/store.ts` | Modify | Add `selectionAnchor` to `AppStore`, `DocViewState`, `captureViewState`, `clearSelection` |
+| `src/store.test.ts` | Modify | Add tests for `selectionAnchor` behaviour |
+| `src/hooks/useKeyboardNav.ts` | **Create** | All keyboard nav logic |
+| `src/hooks/useKeyboardNav.test.ts` | **Create** | Unit tests for the hook |
+| `src/App.tsx` | Modify | Call `useKeyboardNav`, create `sidebarRef`, pass to `PageSidebar` |
+| `src/components/PageSidebar.tsx` | Modify | Accept `containerRef` prop; replace local `anchorRef` with store `selectionAnchor` |
+| `src/components/ShortcutOverlay.tsx` | Modify | Add Page Navigation section, rename Navigation→Tabs, add two-column layout for dual-binding sections |
+
+---
+
+## Task 1 — Store: add `selectionAnchor`
+
+**Files:**
+- Modify: `src/store.ts`
+- Modify: `src/store.test.ts`
+
+### Step 1.1 — Write failing tests
+
+Add to the bottom of `src/store.test.ts`:
+
+```typescript
+// ---------------------------------------------------------------------------
+// selectionAnchor
+// ---------------------------------------------------------------------------
+
+describe("selectionAnchor", () => {
+  beforeEach(() => {
+    useAppStore.setState({ selectionAnchor: null, selectedPages: new Set() });
+  });
+
+  it("starts null", () => {
+    expect(useAppStore.getState().selectionAnchor).toBeNull();
+  });
+
+  it("setSelectionAnchor(3) sets anchor to 3", () => {
+    useAppStore.getState().setSelectionAnchor(3);
+    expect(useAppStore.getState().selectionAnchor).toBe(3);
+  });
+
+  it("setSelectionAnchor(null) clears the anchor", () => {
+    useAppStore.setState({ selectionAnchor: 5 });
+    useAppStore.getState().setSelectionAnchor(null);
+    expect(useAppStore.getState().selectionAnchor).toBeNull();
+  });
+
+  it("clearSelection() also resets selectionAnchor to null", () => {
+    useAppStore.setState({ selectionAnchor: 2, selectedPages: new Set([1, 2, 3]) });
+    useAppStore.getState().clearSelection();
+    expect(useAppStore.getState().selectedPages.size).toBe(0);
+    expect(useAppStore.getState().selectionAnchor).toBeNull();
+  });
+
+  it("selectionAnchor is saved and restored on tab switch", () => {
+    useAppStore.setState({
+      tabs: [],
+      activeDocId: null,
+      docViewStates: new Map(),
+      activePage: 0,
+      zoom: 75,
+      zoomMode: "manual",
+      selectedPages: new Set(),
+      isDirty: false,
+      selectionAnchor: null,
+    });
+    useAppStore.getState().addTab(MANIFEST_A);
+    useAppStore.getState().setSelectionAnchor(4);
+
+    useAppStore.getState().addTab(MANIFEST_B);
+    // anchor should reset for new doc
+    expect(useAppStore.getState().selectionAnchor).toBeNull();
+
+    // switch back to A
+    useAppStore.getState().setActiveDocId(1);
+    expect(useAppStore.getState().selectionAnchor).toBe(4);
+  });
+});
+```
+
+- [ ] **Step 1.2 — Run tests and confirm they fail**
+
+```bash
+pnpm exec vitest run src/store.test.ts
+```
+
+Expected: 5 failures mentioning `selectionAnchor` not found.
+
+- [ ] **Step 1.3 — Update `DocViewState` interface and `DEFAULT_DOC_VIEW_STATE`**
+
+In `src/store.ts`, update the `DocViewState` interface:
+
+```typescript
+export interface DocViewState {
+  activePage: number;
+  zoom: number;
+  zoomMode: ZoomMode;
+  selectedPages: ReadonlySet<number>;
+  isDirty: boolean;
+  selectionAnchor: number | null;
+}
+```
+
+Update `DEFAULT_DOC_VIEW_STATE`:
+
+```typescript
+export const DEFAULT_DOC_VIEW_STATE: DocViewState = {
+  activePage: 0,
+  zoom: 75,
+  zoomMode: "manual",
+  selectedPages: new Set(),
+  isDirty: false,
+  selectionAnchor: null,
+};
+```
+
+- [ ] **Step 1.4 — Update `captureViewState`**
+
+```typescript
+function captureViewState(s: AppStore): DocViewState {
+  return {
+    activePage: s.activePage,
+    zoom: s.zoom,
+    zoomMode: s.zoomMode,
+    selectedPages: s.selectedPages,
+    isDirty: s.isDirty,
+    selectionAnchor: s.selectionAnchor,
+  };
+}
+```
+
+- [ ] **Step 1.5 — Add `selectionAnchor` to `AppStore` interface**
+
+In the `AppStore` interface, add after the `clearSelection` and `selectAll` lines:
+
+```typescript
+selectionAnchor: number | null;
+setSelectionAnchor: (i: number | null) => void;
+```
+
+- [ ] **Step 1.6 — Implement in the store body**
+
+Replace the existing `clearSelection` line:
+
+```typescript
+clearSelection: () => set({ selectedPages: new Set<number>() }),
+```
+
+with:
+
+```typescript
+clearSelection: () => set({ selectedPages: new Set<number>(), selectionAnchor: null }),
+```
+
+Add after `clearSelection` and before `selectAll`:
+
+```typescript
+selectionAnchor: null,
+setSelectionAnchor: (i) => set({ selectionAnchor: i }),
+```
+
+- [ ] **Step 1.7 — Run tests and confirm they pass**
+
+```bash
+pnpm exec vitest run src/store.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 1.8 — Commit**
+
+```bash
+git add src/store.ts src/store.test.ts
+git commit -m "feat: add selectionAnchor to store and DocViewState"
+```
+
+---
+
+## Task 2 — `useKeyboardNav` hook
+
+**Files:**
+- Create: `src/hooks/useKeyboardNav.test.ts`
+- Create: `src/hooks/useKeyboardNav.ts`
+
+### Step 2.1 — Write the test file
+
+Create `src/hooks/useKeyboardNav.test.ts`:
+
+```typescript
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useKeyboardNav } from "./useKeyboardNav";
+import { useAppStore } from "@/store";
+import type { DocumentManifest } from "@/types";
+
+// Minimal tab fixture
+const MANIFEST: DocumentManifest = {
+  doc_id: 1,
+  filename: "test.pdf",
+  path: "/test.pdf",
+  page_count: 10,
+  page_sizes: [],
+  can_undo: false,
+  can_redo: false,
+};
+
+function fireKey(key: string, extra: Partial<KeyboardEventInit> = {}) {
+  window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...extra }));
+}
+
+function makeRefs(sidebarEl?: HTMLElement | null) {
+  const scrollToPage = vi.fn();
+  const pageViewerRef = { current: { scrollToPage } } as any;
+  const sidebarRef = { current: sidebarEl ?? null } as any;
+  return { scrollToPage, pageViewerRef, sidebarRef };
+}
+
+beforeEach(() => {
+  useAppStore.setState({
+    tabs: [],
+    activeDocId: null,
+    docViewStates: new Map(),
+    activePage: 0,
+    zoom: 75,
+    zoomMode: "manual",
+    selectedPages: new Set(),
+    isDirty: false,
+    selectionAnchor: null,
+  });
+  useAppStore.getState().addTab(MANIFEST);
+  useAppStore.setState({ activePage: 5 }); // start mid-document
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("page navigation — no document open", () => {
+  it("does not call scrollToPage when activeDocId is null", () => {
+    useAppStore.setState({ activeDocId: null });
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("j");
+    expect(scrollToPage).not.toHaveBeenCalled();
+  });
+});
+
+describe("page navigation — input guard", () => {
+  it("does not fire when target is an <input>", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "j", bubbles: true, target: input } as any)
+    );
+    // Use Object.defineProperty trick since KeyboardEvent target is read-only
+    const event = new KeyboardEvent("keydown", { key: "j", bubbles: true });
+    Object.defineProperty(event, "target", { value: input });
+    window.dispatchEvent(event);
+    expect(scrollToPage).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+  });
+});
+
+describe("j / PageDown — next page", () => {
+  it("j scrolls to activePage + 1", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("j");
+    expect(scrollToPage).toHaveBeenCalledWith(6);
+  });
+
+  it("PageDown scrolls to activePage + 1", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("PageDown");
+    expect(scrollToPage).toHaveBeenCalledWith(6);
+  });
+
+  it("j clamps at last page", () => {
+    useAppStore.setState({ activePage: 9 }); // last page (pageCount=10)
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("j");
+    expect(scrollToPage).toHaveBeenCalledWith(9);
+  });
+});
+
+describe("k / PageUp — previous page", () => {
+  it("k scrolls to activePage - 1", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("k");
+    expect(scrollToPage).toHaveBeenCalledWith(4);
+  });
+
+  it("PageUp scrolls to activePage - 1", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("PageUp");
+    expect(scrollToPage).toHaveBeenCalledWith(4);
+  });
+
+  it("k clamps at first page", () => {
+    useAppStore.setState({ activePage: 0 });
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("k");
+    expect(scrollToPage).toHaveBeenCalledWith(0);
+  });
+});
+
+describe("G / End — last page", () => {
+  it("G jumps to last page", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("G");
+    expect(scrollToPage).toHaveBeenCalledWith(9);
+  });
+
+  it("End jumps to last page", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("End");
+    expect(scrollToPage).toHaveBeenCalledWith(9);
+  });
+});
+
+describe("Home — first page", () => {
+  it("Home jumps to first page", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("Home");
+    expect(scrollToPage).toHaveBeenCalledWith(0);
+  });
+});
+
+describe("gg — first page", () => {
+  it("two g presses within 500ms jump to first page", () => {
+    vi.useFakeTimers();
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("g");
+    vi.advanceTimersByTime(400);
+    fireKey("g");
+    expect(scrollToPage).toHaveBeenCalledWith(0);
+  });
+
+  it("two g presses more than 500ms apart do not jump", () => {
+    vi.useFakeTimers();
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("g");
+    vi.advanceTimersByTime(501);
+    fireKey("g");
+    expect(scrollToPage).not.toHaveBeenCalled();
+  });
+
+  it("single g press does not jump", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("g");
+    expect(scrollToPage).not.toHaveBeenCalled();
+  });
+});
+
+describe("selection expansion — sidebar guard", () => {
+  function makeSidebarSetup() {
+    const sidebarEl = document.createElement("div");
+    document.body.appendChild(sidebarEl);
+    const child = document.createElement("button");
+    child.setAttribute("tabindex", "0");
+    sidebarEl.appendChild(child);
+    child.focus();
+    return { sidebarEl, cleanup: () => document.body.removeChild(sidebarEl) };
+  }
+
+  it("J (Shift+j) does not fire when sidebar not focused", () => {
+    const { pageViewerRef, sidebarRef } = makeRefs(null);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ selectionAnchor: 5 });
+    fireKey("J");
+    expect(useAppStore.getState().selectedPages.size).toBe(0);
+  });
+
+  it("J (Shift+j) expands selection down when sidebar focused", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 5, selectionAnchor: 5 });
+    fireKey("J");
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([5, 6]);
+    expect(useAppStore.getState().activePage).toBe(6);
+    cleanup();
+  });
+
+  it("K (Shift+k) expands selection up when sidebar focused", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 5, selectionAnchor: 5 });
+    fireKey("K");
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([4, 5]);
+    expect(useAppStore.getState().activePage).toBe(4);
+    cleanup();
+  });
+
+  it("Shift+ArrowDown expands selection down when sidebar focused", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 5, selectionAnchor: 5 });
+    fireKey("ArrowDown", { shiftKey: true });
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([5, 6]);
+    cleanup();
+  });
+
+  it("Shift+ArrowUp expands selection up when sidebar focused", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 5, selectionAnchor: 5 });
+    fireKey("ArrowUp", { shiftKey: true });
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([4, 5]);
+    cleanup();
+  });
+
+  it("selection expansion uses activePage as fallback anchor when selectionAnchor is null", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 3, selectionAnchor: null });
+    fireKey("J");
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([3, 4]);
+    cleanup();
+  });
+});
+```
+
+- [ ] **Step 2.2 — Run tests and confirm they fail**
+
+```bash
+pnpm exec vitest run src/hooks/useKeyboardNav.test.ts
+```
+
+Expected: module `useKeyboardNav` not found.
+
+- [ ] **Step 2.3 — Create `src/hooks/useKeyboardNav.ts`**
+
+```typescript
+import { useEffect, useRef } from "react";
+import type { RefObject } from "react";
+import { useAppStore } from "@/store";
+import type { PageViewerHandle } from "@/components/PageViewer";
+
+interface Options {
+  pageViewerRef: RefObject<PageViewerHandle | null>;
+  sidebarRef: RefObject<HTMLElement | null>;
+}
+
+function isInputFocused(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    target.contentEditable === "true"
+  );
+}
+
+export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
+  const lastGRef = useRef<number>(0);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (isInputFocused(e.target)) return;
+
+      const state = useAppStore.getState();
+      if (state.activeDocId === null) return;
+
+      const tab = state.tabs.find((t) => t.docId === state.activeDocId);
+      if (!tab || tab.pageCount === 0) return;
+
+      const { activePage } = state;
+      const pageCount = tab.pageCount;
+      const sidebarFocused =
+        sidebarRef.current != null &&
+        sidebarRef.current.contains(document.activeElement);
+
+      // gg — first page
+      if (e.key === "g" && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
+        const now = Date.now();
+        if (now - lastGRef.current <= 500) {
+          e.preventDefault();
+          pageViewerRef.current?.scrollToPage(0);
+          lastGRef.current = 0;
+        } else {
+          lastGRef.current = now;
+        }
+        return;
+      }
+
+      // G — last page
+      if (e.key === "G" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(pageCount - 1);
+        return;
+      }
+
+      // j — next page
+      if (e.key === "j" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(Math.min(activePage + 1, pageCount - 1));
+        return;
+      }
+
+      // k — previous page
+      if (e.key === "k" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(Math.max(activePage - 1, 0));
+        return;
+      }
+
+      // J (Shift+j) — expand selection down (sidebar only)
+      if (e.key === "J" && !e.metaKey && !e.ctrlKey) {
+        if (!sidebarFocused) return;
+        e.preventDefault();
+        const { selectionAnchor } = useAppStore.getState();
+        const anchor = selectionAnchor ?? activePage;
+        const cursor = Math.min(activePage + 1, pageCount - 1);
+        useAppStore.getState().setActivePage(cursor);
+        useAppStore.getState().selectPageRange(anchor, cursor);
+        return;
+      }
+
+      // K (Shift+k) — expand selection up (sidebar only)
+      if (e.key === "K" && !e.metaKey && !e.ctrlKey) {
+        if (!sidebarFocused) return;
+        e.preventDefault();
+        const { selectionAnchor } = useAppStore.getState();
+        const anchor = selectionAnchor ?? activePage;
+        const cursor = Math.max(activePage - 1, 0);
+        useAppStore.getState().setActivePage(cursor);
+        useAppStore.getState().selectPageRange(anchor, cursor);
+        return;
+      }
+
+      // PageDown — next page
+      if (e.key === "PageDown") {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(Math.min(activePage + 1, pageCount - 1));
+        return;
+      }
+
+      // PageUp — previous page
+      if (e.key === "PageUp") {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(Math.max(activePage - 1, 0));
+        return;
+      }
+
+      // Home — first page
+      if (e.key === "Home") {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(0);
+        return;
+      }
+
+      // End — last page
+      if (e.key === "End") {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(pageCount - 1);
+        return;
+      }
+
+      // Shift+ArrowDown — expand selection down (sidebar only)
+      if (e.key === "ArrowDown" && e.shiftKey && !e.metaKey && !e.ctrlKey) {
+        if (!sidebarFocused) return;
+        e.preventDefault();
+        const { selectionAnchor } = useAppStore.getState();
+        const anchor = selectionAnchor ?? activePage;
+        const cursor = Math.min(activePage + 1, pageCount - 1);
+        useAppStore.getState().setActivePage(cursor);
+        useAppStore.getState().selectPageRange(anchor, cursor);
+        return;
+      }
+
+      // Shift+ArrowUp — expand selection up (sidebar only)
+      if (e.key === "ArrowUp" && e.shiftKey && !e.metaKey && !e.ctrlKey) {
+        if (!sidebarFocused) return;
+        e.preventDefault();
+        const { selectionAnchor } = useAppStore.getState();
+        const anchor = selectionAnchor ?? activePage;
+        const cursor = Math.max(activePage - 1, 0);
+        useAppStore.getState().setActivePage(cursor);
+        useAppStore.getState().selectPageRange(anchor, cursor);
+        return;
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [pageViewerRef, sidebarRef]);
+}
+```
+
+- [ ] **Step 2.4 — Run tests and confirm they pass**
+
+```bash
+pnpm exec vitest run src/hooks/useKeyboardNav.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2.5 — Run full test suite to confirm no regressions**
+
+```bash
+make test-frontend
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2.6 — Commit**
+
+```bash
+git add src/hooks/useKeyboardNav.ts src/hooks/useKeyboardNav.test.ts
+git commit -m "feat: useKeyboardNav hook with Vim-style page navigation"
+```
+
+---
+
+## Task 3 — Wire hook and `sidebarRef` in `App.tsx`
+
+**Files:**
+- Modify: `src/App.tsx`
+
+- [ ] **Step 3.1 — Add `sidebarRef` and `useKeyboardNav` import**
+
+Add to the imports at the top of `src/App.tsx`:
+
+```typescript
+import { useKeyboardNav } from "@/hooks/useKeyboardNav";
+```
+
+- [ ] **Step 3.2 — Add `sidebarRef` declaration**
+
+In the `App` function, after the existing `viewerRef` declaration:
+
+```typescript
+const viewerRef = useRef<PageViewerHandle>(null);
+// Stable ref for use inside event listener closures
+const activeTabRef = useRef<TabEntry | null>(null);
+```
+
+Add:
+
+```typescript
+const sidebarRef = useRef<HTMLDivElement>(null);
+```
+
+- [ ] **Step 3.3 — Call the hook**
+
+After the `useTheme()` call, add:
+
+```typescript
+useKeyboardNav({ pageViewerRef: viewerRef, sidebarRef });
+```
+
+- [ ] **Step 3.4 — Pass `containerRef` to `PageSidebar`**
+
+Find the `PageSidebar` usage in the JSX:
+
+```tsx
+<PageSidebar
+  docId={activeTab.docId}
+  pageSizes={activeTab.pageSizes}
+  onScrollToPage={(i) => viewerRef.current?.scrollToPage(i)}
+  onBugReport={openBugReportForError}
+/>
+```
+
+Replace with:
+
+```tsx
+<PageSidebar
+  docId={activeTab.docId}
+  pageSizes={activeTab.pageSizes}
+  onScrollToPage={(i) => viewerRef.current?.scrollToPage(i)}
+  onBugReport={openBugReportForError}
+  containerRef={sidebarRef}
+/>
+```
+
+---
+
+## Task 4 — `PageSidebar`: accept `containerRef`, use store anchor
+
+**Files:**
+- Modify: `src/components/PageSidebar.tsx`
+
+- [ ] **Step 4.1 — Add `containerRef` to `Props` and import `RefObject`**
+
+Replace the existing `Props` interface:
+
+```typescript
+interface Props {
+  docId: number;
+  pageSizes: PageSize[];
+  onScrollToPage(index: number): void;
+  onBugReport(message: string): void;
+}
+```
+
+with:
+
+```typescript
+import type { RefObject } from "react";
+
+interface Props {
+  docId: number;
+  pageSizes: PageSize[];
+  onScrollToPage(index: number): void;
+  onBugReport(message: string): void;
+  containerRef?: RefObject<HTMLDivElement | null>;
+}
+```
+
+Note: add the `RefObject` import to the existing `react` import line:
+
+```typescript
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+```
+
+- [ ] **Step 4.2 — Replace `anchorRef` with store `selectionAnchor`**
+
+In the function signature, add the new prop:
+
+```typescript
+export function PageSidebar({ docId, pageSizes, onScrollToPage, onBugReport, containerRef: externalRef }: Props) {
+  const internalRef = useRef<HTMLDivElement>(null);
+  const containerRef = externalRef ?? internalRef;
+```
+
+Remove the `anchorRef` line:
+```typescript
+// DELETE this line:
+const anchorRef = useRef(0);
+```
+
+Add store selectors for `selectionAnchor` and `setSelectionAnchor` alongside the existing ones:
+
+```typescript
+const selectedPages = useAppStore((s) => s.selectedPages);
+const togglePageSelection = useAppStore((s) => s.togglePageSelection);
+const selectPageRange = useAppStore((s) => s.selectPageRange);
+const clearSelection = useAppStore((s) => s.clearSelection);
+const setSelectionAnchor = useAppStore((s) => s.setSelectionAnchor);
+```
+
+- [ ] **Step 4.3 — Update `handleThumbClick` to use store anchor**
+
+Replace the existing `handleThumbClick`:
+
+```typescript
+const handleThumbClick = useCallback(
+  (index: number, e: React.MouseEvent) => {
+    if (e.metaKey || e.ctrlKey) {
+      const isAdding = !useAppStore.getState().selectedPages.has(index);
+      togglePageSelection(index);
+      if (isAdding) setSelectionAnchor(index);
+    } else if (e.shiftKey) {
+      const anchor = useAppStore.getState().selectionAnchor ?? index;
+      selectPageRange(anchor, index);
+    } else {
+      clearSelection();
+      setSelectionAnchor(index);
+      onScrollToPage(index);
+    }
+  },
+  [togglePageSelection, selectPageRange, clearSelection, setSelectionAnchor, onScrollToPage]
+);
+```
+
+- [ ] **Step 4.4 — Attach `containerRef` to the scroll div**
+
+Find the inner scroll div:
+
+```tsx
+<div ref={containerRef} className="h-full overflow-y-auto py-2 pl-3 pr-6">
+```
+
+This line already uses `containerRef` — it now uses the merged ref (external ?? internal), so no change needed here as long as step 4.2 renamed the variable correctly.
+
+- [ ] **Step 4.5 — Run tests**
+
+```bash
+make test-frontend
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4.6 — Commit**
+
+```bash
+git add src/App.tsx src/components/PageSidebar.tsx
+git commit -m "feat: wire useKeyboardNav hook and sidebarRef in App"
+```
+
+---
+
+## Task 5 — `ShortcutOverlay`: two-column layout + Page Navigation section
+
+**Files:**
+- Modify: `src/components/ShortcutOverlay.tsx`
+
+- [ ] **Step 5.1 — Update `ShortcutOverlay.tsx`**
+
+Replace the entire file contents with:
+
+```typescript
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { isMac, modKey, shiftModKey } from "@/lib/platform";
+
+interface Props {
+  open: boolean;
+  onClose(): void;
+}
+
+interface SingleRow {
+  action: string;
+  keys: string[];
+}
+
+interface DualRow {
+  action: string;
+  standard: string | null;
+  vim: string | null;
+}
+
+interface SingleSection {
+  kind: "single";
+  label: string;
+  rows: SingleRow[];
+}
+
+interface DualSection {
+  kind: "dual";
+  label: string;
+  rows: DualRow[];
+}
+
+type Section = SingleSection | DualSection;
+
+function buildSections(): Section[] {
+  const mod = modKey();
+  const shiftMod = shiftModKey();
+  return [
+    {
+      kind: "single",
+      label: "File",
+      rows: [
+        { action: "Open PDF", keys: [`${mod}O`] },
+        { action: "Save",     keys: [`${mod}S`] },
+        { action: "Save As",  keys: [`${shiftMod}S`] },
+        { action: "Close",    keys: [`${mod}W`] },
+      ],
+    },
+    {
+      kind: "dual",
+      label: "Page Navigation",
+      rows: [
+        { action: "Next page",     standard: "PgDn", vim: "j" },
+        { action: "Previous page", standard: "PgUp",  vim: "k" },
+        { action: "First page",    standard: "Home",  vim: "gg" },
+        { action: "Last page",     standard: "End",   vim: "G" },
+      ],
+    },
+    {
+      kind: "single",
+      label: "View",
+      rows: [
+        { action: "Document Info",  keys: [`${mod}I`] },
+        { action: "Zoom In",        keys: [`${mod}+`] },
+        { action: "Zoom Out",       keys: [`${mod}−`] },
+        { action: "Fit Width",      keys: [`${mod}0`] },
+        { action: "Toggle Sidebar", keys: [`${mod}B`] },
+      ],
+    },
+    {
+      kind: "single",
+      label: "Tabs",
+      rows: [
+        {
+          action: "Next Tab",
+          keys: isMac ? ["⌘⇧]"] : ["Ctrl+Tab", "Ctrl+PgDn"],
+        },
+        {
+          action: "Previous Tab",
+          keys: isMac ? ["⌘⇧["] : ["Ctrl+Shift+Tab", "Ctrl+PgUp"],
+        },
+        {
+          action: "Jump to Tab",
+          keys: [`${mod}1 – ${mod}9`],
+        },
+      ],
+    },
+    {
+      kind: "dual",
+      label: "Selection",
+      rows: [
+        { action: "Select All",    standard: `${mod}A`, vim: null },
+        { action: "Expand down",   standard: "⇧↓",      vim: "⇧j" },
+        { action: "Expand up",     standard: "⇧↑",      vim: "⇧k" },
+      ],
+    },
+    {
+      kind: "single",
+      label: "Help",
+      rows: [
+        { action: "Keyboard Shortcuts", keys: ["?"] },
+      ],
+    },
+  ];
+}
+
+function Kbd({ children }: { children: string }) {
+  return (
+    <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-xs">
+      {children}
+    </kbd>
+  );
+}
+
+function SingleSectionView({ section }: { section: SingleSection }) {
+  return (
+    <div>
+      <p className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {section.label}
+      </p>
+      <div className="space-y-1">
+        {section.rows.map((row) => (
+          <div key={row.action} className="flex items-center justify-between text-sm">
+            <span>{row.action}</span>
+            <div className="flex items-center gap-1">
+              {row.keys.map((k) => <Kbd key={k}>{k}</Kbd>)}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DualSectionView({ section }: { section: DualSection }) {
+  return (
+    <div>
+      <p className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {section.label}
+      </p>
+      {/* Column headers */}
+      <div className="mb-1 grid grid-cols-[1fr_88px_56px] gap-x-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+        <span />
+        <span className="text-right">Standard</span>
+        <span className="text-right">Vim</span>
+      </div>
+      <div className="space-y-1">
+        {section.rows.map((row) => (
+          <div
+            key={row.action}
+            className="grid grid-cols-[1fr_88px_56px] items-center gap-x-2 text-sm"
+          >
+            <span>{row.action}</span>
+            <div className="flex justify-end">
+              {row.standard ? <Kbd>{row.standard}</Kbd> : <span className="text-muted-foreground/40">—</span>}
+            </div>
+            <div className="flex justify-end">
+              {row.vim ? <Kbd>{row.vim}</Kbd> : <span className="text-muted-foreground/40">—</span>}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ShortcutOverlay({ open, onClose }: Props) {
+  const sections = buildSections();
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => { if (!next) onClose(); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Keyboard Shortcuts</DialogTitle>
+        </DialogHeader>
+
+        <div className="mt-2 space-y-5">
+          {sections.map((section) =>
+            section.kind === "dual" ? (
+              <DualSectionView key={section.label} section={section} />
+            ) : (
+              <SingleSectionView key={section.label} section={section} />
+            )
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 5.2 — Run tests**
+
+```bash
+make test-frontend
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5.3 — Commit**
+
+```bash
+git add src/components/ShortcutOverlay.tsx
+git commit -m "feat: shortcut overlay — Page Navigation section, two-column Vim layout"
+```
+
+---
+
+## Verification
+
+- [ ] `make test-frontend` — all tests green
+- [ ] `cargo tauri dev` — open a multi-page PDF
+- [ ] Press `j` / `k` — pages advance / retreat one at a time
+- [ ] Press `PgDn` / `PgUp` — same behaviour
+- [ ] Press `gg` (two g presses within ~500ms) — jumps to page 1
+- [ ] Press `G` — jumps to last page; press `End` — same
+- [ ] Press `Home` — jumps to first page
+- [ ] Click into an address bar or any future text input; press `j` — no navigation
+- [ ] Click a thumbnail to focus the sidebar; press `J` (Shift+j) — selection expands downward; press `K` — selection expands upward
+- [ ] Press `⇧↓` and `⇧↑` with sidebar focused — same expansion behaviour
+- [ ] Switch tabs while sidebar has a selection — return to the original tab, anchor is still correct
+- [ ] Press `?` — overlay shows "Page Navigation" section with Standard/Vim columns; "Navigation" is now "Tabs"; Selection section has Expand down/up rows
+- [ ] Press `Escape` — overlay dismisses

--- a/docs/superpowers/specs/2026-04-18-keyboard-navigation-design.md
+++ b/docs/superpowers/specs/2026-04-18-keyboard-navigation-design.md
@@ -1,0 +1,100 @@
+# Keyboard Navigation Design (Issue #7)
+
+## Context
+
+Collate's design principle is "mouse and keyboard are equals." Phase 1 milestone 7 requires full Vim-style page navigation (j/k, gg/G) with standard fallbacks (PgUp/PgDn, Home/End), plus a shortcut reference overlay on `?`. The overlay component and `?` binding already exist; no page navigation keys are wired yet.
+
+## Architecture
+
+All keyboard handling lives in a single hook: `src/hooks/useKeyboardNav.ts`. It is called once from `App.tsx` and attaches one `window` keydown listener. This is the single place to look for all keyboard navigation behaviour — no keyboard logic in individual components.
+
+The hook receives two refs:
+- `pageViewerRef` — the existing `PageViewerHandle` ref (exposes `scrollToPage`)
+- `sidebarRef` — a `RefObject<HTMLElement>` pointing to the sidebar container (new, threaded from `App.tsx` → `PageSidebar`)
+
+## Focus Guards
+
+Two guards, applied per-binding:
+
+- **Global guard** — skip if `event.target` is an `<input>`, `<textarea>`, `<select>`, or has `contentEditable === "true"`. Prevents bindings firing when the user is typing.
+- **Sidebar guard** — Shift+↑/↓/j/k only fire when `sidebarRef.current?.contains(document.activeElement)` is true. Prevents selection expansion when the viewer or another element has focus.
+
+## Bindings
+
+| Action | Standard | Vim | Guard |
+|--------|----------|-----|-------|
+| Next page | PgDn | j | global |
+| Previous page | PgUp | k | global |
+| First page | Home | gg | global |
+| Last page | End | G | global |
+| Expand selection down | Shift+↓ | Shift+j | sidebar focused |
+| Expand selection up | Shift+↑ | Shift+k | sidebar focused |
+
+Page bounds are clamped: next page stops at `pageCount - 1`, previous stops at `0`.
+
+## `gg` Detection
+
+A `useRef<number>` holds the timestamp of the last `g` keypress. On each `g`, if the previous press was within 500 ms, trigger first-page jump and reset the ref. Otherwise record the timestamp.
+
+## Selection Anchor
+
+Expanding selection with keyboard requires a stable anchor (the page where selection started). Add to the zustand store:
+
+```ts
+selectionAnchor: number | null        // index of anchor page, null when no selection
+setSelectionAnchor: (i: number | null) => void
+```
+
+The anchor is stored in the zustand store (not a local ref) so it survives tab switches. When `clearSelection` is called, `selectionAnchor` is also reset to `null`.
+
+Anchor is set to the clicked page on a **plain click** (no modifier) in `PageSidebar`. On Shift+click (range selection) the anchor is left unchanged — the clicked page becomes the range end, not the new anchor. On Ctrl/Cmd+click (toggle), the anchor is updated to the toggled page only if it is being added (not removed).
+
+Shift+↑/↓/j/k call `selectPageRange(selectionAnchor, newCursor)` using the existing store action.
+
+## ShortcutOverlay Changes
+
+`ShortcutOverlay.tsx` receives two changes:
+
+1. **New "Page Navigation" section** inserted after "File", using the two-column Standard/Vim layout:
+
+   | Action | Standard | Vim |
+   |--------|----------|-----|
+   | Next page | PgDn | j |
+   | Previous page | PgUp | k |
+   | First page | Home | gg |
+   | Last page | End | G |
+
+2. **"Navigation" section renamed to "Tabs"** to distinguish from page navigation.
+
+3. **Selection section gains two new rows** using the same two-column layout:
+
+   | Action | Standard | Vim |
+   |--------|----------|-----|
+   | Select All | ⌘A | — |
+   | Expand down | Shift+↓ | Shift+j |
+   | Expand up | Shift+↑ | Shift+k |
+
+The two-column layout uses fixed-width wrapper divs (`display:flex; justify-content:flex-end`) so column alignment holds without stretching the `<kbd>` chips.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/hooks/useKeyboardNav.ts` | **new** — all keyboard nav logic |
+| `src/App.tsx` | call `useKeyboardNav`, thread `sidebarRef` to `PageSidebar` |
+| `src/store.ts` | add `selectionAnchor`, `setSelectionAnchor`; reset anchor in `clearSelection` |
+| `src/components/ShortcutOverlay.tsx` | add Page Navigation section, rename Navigation→Tabs, add selection rows |
+| `src/components/PageSidebar.tsx` | accept and forward `sidebarRef` prop; call `setSelectionAnchor` on first selection |
+
+## Verification
+
+1. `make test-frontend` — all existing tests pass
+2. Open a PDF, click the viewer area, press `j`/`k` — pages advance/retreat
+3. Press `PgDn`/`PgUp` — same behaviour
+4. Press `gg` (two g's within 500ms) — jumps to page 1
+5. Press `G` / `End` — jumps to last page
+6. Click a text input (e.g. any future search field), press `j` — no navigation fires
+7. Click a sidebar thumbnail to focus sidebar, Shift+↓ — selection expands downward; Shift+↑ contracts/expands upward
+8. Switch tabs while sidebar selection is active — anchor survives, expansion continues correctly on return
+9. Press `?` — overlay shows Page Navigation section with correct two-column layout
+10. Press `Escape` or `?` again — overlay dismisses

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/geist": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/geist": "^5.2.8",
     "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-virtual": "^3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@fontsource-variable/geist':
         specifier: ^5.2.8
         version: 5.2.8
@@ -319,6 +328,28 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@dotenvx/dotenvx@1.60.0':
     resolution: {integrity: sha512-zWepVRNan/5gCALiT/QCHVsmxvq81xenBqGRyoTUy+ClJ+Mgs+tTJ6h4f65nqs8ijVFe6xg4lIQAIwe+HfgWXg==}
@@ -3703,6 +3734,31 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@dotenvx/dotenvx@1.60.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/modifiers':
+        specifier: ^9.0.0
+        version: 9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@dnd-kit/sortable':
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
@@ -339,6 +342,12 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  '@dnd-kit/modifiers@9.0.0':
+    resolution: {integrity: sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
 
   '@dnd-kit/sortable@10.0.0':
     resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
@@ -3746,6 +3755,13 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/modifiers@9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
       tslib: 2.8.1
 
   '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -517,6 +517,7 @@ fn update_recent_menu(app: tauri::AppHandle, state: State<AppState>, paths: Vec<
 const PDF_MENU_IDS: &[&str] = &[
     "close", "print", "undo", "redo", "select-all", "find",
     "save", "save-as",
+    "next-tab", "prev-tab",
     "zoom-in", "zoom-out", "zoom-fit-width",
     "doc-info",
     // Document menu
@@ -635,6 +636,8 @@ pub fn run() {
                 "display-continuous" => { set_display_checks(app, "continuous"); let _ = app.emit("menu-display", "continuous"); }
                 "display-single"     => { set_display_checks(app, "single");     let _ = app.emit("menu-display", "single"); }
                 "display-spread"     => { set_display_checks(app, "spread");     let _ = app.emit("menu-display", "spread"); }
+                "next-tab"       => { let _ = app.emit("menu-next-tab",       ()); }
+                "prev-tab"       => { let _ = app.emit("menu-prev-tab",       ()); }
                 "zoom-in"        => { let _ = app.emit("menu-zoom-in",        ()); }
                 "zoom-out"       => { let _ = app.emit("menu-zoom-out",       ()); }
                 "zoom-fit-width" => { let _ = app.emit("menu-zoom-fit-width", ()); }

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -26,6 +26,8 @@ use tauri::{
 ///   "split"              — Document → Split Document…
 ///   "merge"              — Document → Merge Document…
 ///   "import-pages"       — Document → Import Pages…
+///   "next-tab"           — View → Next Tab
+///   "prev-tab"           — View → Previous Tab
 ///   "display-continuous" — View → Page Display → Continuous Scroll
 ///   "display-single"     — View → Page Display → Single Page
 ///   "display-spread"     — View → Page Display → Two-Page Spread
@@ -102,6 +104,23 @@ pub fn build_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
         ],
     )?;
 
+    // ── View → Tab navigation ─────────────────────────────────────────────
+    // macOS: ⌘⇧] / ⌘⇧[  (matches Safari / Terminal)
+    // Win/Linux: Ctrl+PageDown / Ctrl+PageUp  (matches Chrome DevTools / VS Code)
+    let next_tab_accel: Option<&str> = if cfg!(target_os = "macos") {
+        Some("Shift+CmdOrCtrl+]")
+    } else {
+        Some("Ctrl+PageDown")
+    };
+    let prev_tab_accel: Option<&str> = if cfg!(target_os = "macos") {
+        Some("Shift+CmdOrCtrl+[")
+    } else {
+        Some("Ctrl+PageUp")
+    };
+    let next_tab  = MenuItem::with_id(app, "next-tab",  "Next Tab",      false, next_tab_accel)?;
+    let prev_tab  = MenuItem::with_id(app, "prev-tab",  "Previous Tab",  false, prev_tab_accel)?;
+    let sep_tabs  = PredefinedMenuItem::separator(app)?;
+
     // ── View → Page Display ────────────────────────────────────────────────
     let display_continuous = CheckMenuItem::with_id(app, "display-continuous", "Continuous Scroll", false, true,  None::<&str>)?;
     let display_single     = CheckMenuItem::with_id(app, "display-single",     "Single Page",       false, false, None::<&str>)?;
@@ -129,7 +148,7 @@ pub fn build_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
         app,
         "View",
         true,
-        &[&display_menu, &sep_display, &doc_info, &sep_info, &zoom_menu, &sep_zoom, &appearance],
+        &[&next_tab, &prev_tab, &sep_tabs, &display_menu, &sep_display, &doc_info, &sep_info, &zoom_menu, &sep_zoom, &appearance],
     )?;
 
     // ── Help (required by macOS HIG) ───────────────────────────────────────

--- a/src/App.css
+++ b/src/App.css
@@ -15,6 +15,7 @@ body[data-sidebar-dragging] [data-slot="sidebar-container"] {
 @theme inline {
   --font-heading: var(--font-sans);
   --font-sans: 'Geist Variable', sans-serif;
+  --color-tab-inactive: var(--tab-inactive);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -56,6 +57,7 @@ body[data-sidebar-dragging] [data-slot="sidebar-container"] {
 }
 
 :root {
+  --tab-inactive: oklch(0.935 0 0);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -91,6 +93,7 @@ body[data-sidebar-dragging] [data-slot="sidebar-container"] {
 }
 
 .dark {
+  --tab-inactive: oklch(0.225 0 0);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
@@ -122,6 +125,11 @@ body[data-sidebar-dragging] [data-slot="sidebar-container"] {
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+}
+
+html, body {
+  overflow: hidden;
+  overscroll-behavior: none;
 }
 
 @layer base {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, fireEvent, act } from "@testing-library/react"
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import App from "./App";
-import { useAppStore } from "@/store";
+import { useAppStore, type TabEntry } from "@/store";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
@@ -14,6 +14,11 @@ vi.mock("@tauri-apps/api/event", () => ({
 }));
 vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn().mockResolvedValue(null) }));
 vi.mock("@tauri-apps/api/app", () => ({ getVersion: vi.fn().mockResolvedValue("0.0.0") }));
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: vi.fn().mockResolvedValue(vi.fn()),
+  }),
+}));
 vi.mock("sonner", async (importOriginal) => {
   const actual = await importOriginal<typeof import("sonner")>();
   return { ...actual, toast: { ...actual.toast, error: vi.fn() } };
@@ -34,7 +39,15 @@ const MOCK_MANIFEST = {
 };
 
 beforeEach(() => {
-  useAppStore.setState({ theme: "system", zoom: 75, zoomMode: "manual", activePage: 0 });
+  useAppStore.setState({
+    theme: "system",
+    zoom: 75,
+    zoomMode: "manual",
+    activePage: 0,
+    tabs: [],
+    activeDocId: null,
+    docViewStates: new Map(),
+  });
   (invoke as Mock).mockResolvedValue(undefined);
   (openDialog as Mock).mockResolvedValue(null);
 });
@@ -165,5 +178,134 @@ describe("Edit > Select All menu event", () => {
     });
 
     expect(useAppStore.getState().selectedPages.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tab navigation — keyboard shortcuts
+// ---------------------------------------------------------------------------
+
+const TAB_1: TabEntry = {
+  docId: 1, filename: "a.pdf", path: "/a.pdf",
+  pageCount: 1, pageSizes: [], canUndo: false, canRedo: false, isDirty: false,
+};
+const TAB_2: TabEntry = {
+  docId: 2, filename: "b.pdf", path: "/b.pdf",
+  pageCount: 1, pageSizes: [], canUndo: false, canRedo: false, isDirty: false,
+};
+const TAB_3: TabEntry = {
+  docId: 3, filename: "c.pdf", path: "/c.pdf",
+  pageCount: 1, pageSizes: [], canUndo: false, canRedo: false, isDirty: false,
+};
+
+describe("Tab navigation keyboard shortcuts", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      tabs: [TAB_1, TAB_2, TAB_3],
+      activeDocId: 1,
+      docViewStates: new Map(),
+    });
+  });
+
+  it("⌘} moves to next tab", () => {
+    render(<App />);
+    fireEvent.keyDown(window, { key: "}", metaKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(2);
+  });
+
+  it("⌘{ moves to previous tab", () => {
+    useAppStore.setState({ activeDocId: 2 });
+    render(<App />);
+    fireEvent.keyDown(window, { key: "{", metaKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(1);
+  });
+
+  it("next tab wraps from last to first", () => {
+    useAppStore.setState({ activeDocId: 3 });
+    render(<App />);
+    fireEvent.keyDown(window, { key: "}", metaKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(1);
+  });
+
+  it("prev tab wraps from first to last", () => {
+    render(<App />);
+    fireEvent.keyDown(window, { key: "{", metaKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(3);
+  });
+
+  it("Ctrl+Tab moves to next tab", () => {
+    render(<App />);
+    fireEvent.keyDown(window, { key: "Tab", ctrlKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(2);
+  });
+
+  it("Ctrl+Shift+Tab moves to previous tab", () => {
+    useAppStore.setState({ activeDocId: 2 });
+    render(<App />);
+    fireEvent.keyDown(window, { key: "Tab", ctrlKey: true, shiftKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(1);
+  });
+
+  it("⌘1 / Ctrl+1 jumps to first tab", () => {
+    useAppStore.setState({ activeDocId: 3 });
+    render(<App />);
+    fireEvent.keyDown(window, { key: "1", metaKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(1);
+  });
+
+  it("⌘2 / Ctrl+2 jumps to second tab", () => {
+    render(<App />);
+    fireEvent.keyDown(window, { key: "2", ctrlKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(2);
+  });
+
+  it("⌘9 / Ctrl+9 jumps to last tab when fewer than 9 tabs open", () => {
+    render(<App />);
+    fireEvent.keyDown(window, { key: "9", metaKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(3);
+  });
+
+  it("does nothing when only one tab is open", () => {
+    useAppStore.setState({ tabs: [TAB_1], activeDocId: 1 });
+    render(<App />);
+    fireEvent.keyDown(window, { key: "}", metaKey: true });
+    expect(useAppStore.getState().activeDocId).toBe(1);
+  });
+
+  it("does nothing when no tabs are open", () => {
+    useAppStore.setState({ tabs: [], activeDocId: null });
+    render(<App />);
+    fireEvent.keyDown(window, { key: "}", metaKey: true });
+    expect(useAppStore.getState().activeDocId).toBeNull();
+  });
+});
+
+describe("Tab navigation menu events", () => {
+  let menuHandlers: Record<string, () => void>;
+
+  beforeEach(() => {
+    menuHandlers = {};
+    useAppStore.setState({
+      tabs: [TAB_1, TAB_2, TAB_3],
+      activeDocId: 1,
+      docViewStates: new Map(),
+    });
+    (listen as Mock).mockImplementation((event: string, cb: () => void) => {
+      menuHandlers[event] = cb;
+      return Promise.resolve(vi.fn());
+    });
+  });
+
+  it("menu-next-tab moves to next tab", async () => {
+    render(<App />);
+    await act(async () => { menuHandlers["menu-next-tab"]?.(); });
+    expect(useAppStore.getState().activeDocId).toBe(2);
+  });
+
+  it("menu-prev-tab moves to previous tab", async () => {
+    useAppStore.setState({ activeDocId: 2 });
+    render(<App />);
+    await act(async () => { menuHandlers["menu-prev-tab"]?.(); });
+    expect(useAppStore.getState().activeDocId).toBe(1);
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -383,7 +383,7 @@ function App() {
     // strip appropriate for page thumbnails.
     <SidebarProvider
       defaultOpen={true}
-      className="h-screen overflow-hidden"
+      className="h-screen overflow-hidden overscroll-none"
       style={{ "--sidebar-width": `${sidebarWidth}px` } as React.CSSProperties}
     >
       {activeTab && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,6 @@ import { PageSidebar } from "./components/PageSidebar";
 import { TabBar } from "./components/TabBar";
 import { Toolbar } from "./components/Toolbar";
 import { StatusBar } from "./components/StatusBar";
-import { Separator } from "@/components/ui/separator";
 import { Toaster } from "@/components/ui/sonner";
 import {
   Sidebar,
@@ -421,8 +420,6 @@ function App() {
             onReorder={reorderTabs}
           />
         )}
-
-        <Separator />
 
         <div className="relative flex-1 overflow-hidden min-h-0">
           {activeTab ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { open as openDialog, save as saveDialog } from "@tauri-apps/plugin-dialo
 import { invoke } from "@tauri-apps/api/core";
 import { getVersion } from "@tauri-apps/api/app";
 import { listen } from "@tauri-apps/api/event";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { toast } from "sonner";
 import { BugIcon } from "lucide-react";
 import { BugReportDialog } from "./components/BugReportDialog";
@@ -11,6 +12,7 @@ import { ShortcutOverlay } from "./components/ShortcutOverlay";
 import { EmptyState } from "./components/EmptyState";
 import { PageViewer, PageViewerHandle } from "./components/PageViewer";
 import { PageSidebar } from "./components/PageSidebar";
+import { TabBar } from "./components/TabBar";
 import { Toolbar } from "./components/Toolbar";
 import { StatusBar } from "./components/StatusBar";
 import { Separator } from "@/components/ui/separator";
@@ -20,34 +22,26 @@ import {
   SidebarInset,
   SidebarProvider,
 } from "@/components/ui/sidebar";
-import { useAppStore, ZOOM_STEPS, PageDisplay } from "@/store";
+import { useAppStore, ZOOM_STEPS, PageDisplay, TabEntry } from "@/store";
 import { useTheme } from "@/hooks/useTheme";
 import { platformName } from "@/lib/platform";
-
-interface PageSize {
-  width_pts: number;
-  height_pts: number;
-}
-
-interface DocumentManifest {
-  doc_id: number;
-  page_count: number;
-  filename: string;
-  path: string;
-  page_sizes: PageSize[];
-  can_undo: boolean;
-  can_redo: boolean;
-}
+import { cn } from "@/lib/utils";
+import type { DocumentManifest } from "@/types";
 
 function App() {
-  const [manifest, setManifest] = useState<DocumentManifest | null>(null);
   const [loading, setLoading] = useState(false);
   const [bugReportOpen, setBugReportOpen] = useState(false);
   const [bugPrefill, setBugPrefill] = useState<{ title: string; description: string } | null>(null);
   const [showShortcuts, setShowShortcuts] = useState(false);
+  const [isDragOver, setIsDragOver] = useState(false);
 
   const viewerRef = useRef<PageViewerHandle>(null);
-  const manifestRef = useRef<DocumentManifest | null>(null);
+  // Stable ref for use inside event listener closures
+  const activeTabRef = useRef<TabEntry | null>(null);
+
+  const tabs = useAppStore((s) => s.tabs);
+  const activeDocId = useAppStore((s) => s.activeDocId);
+  const activeTab = tabs.find((t) => t.docId === activeDocId) ?? null;
   const sidebarWidth = useAppStore((s) => s.sidebarWidth);
   const theme = useAppStore((s) => s.theme);
   const setTheme = useAppStore((s) => s.setTheme);
@@ -55,8 +49,13 @@ function App() {
   const infoPanelOpen = useAppStore((s) => s.infoPanelOpen);
   const setInfoPanelOpen = useAppStore((s) => s.setInfoPanelOpen);
   const toggleInfoPanel = useAppStore((s) => s.toggleInfoPanel);
+  const reorderTabs = useAppStore((s) => s.reorderTabs);
+
   // Apply theme (dark class on <html>) and keep it in sync with OS changes
   useTheme();
+
+  // Keep ref in sync so event listeners always see the current active tab
+  useEffect(() => { activeTabRef.current = activeTab; }, [activeTab]);
 
   // Sync the "Open Recent" submenu once on mount with whatever was persisted.
   useEffect(() => {
@@ -64,25 +63,17 @@ function App() {
   }, []);
 
   // Sync native menu checkmarks whenever theme changes.
-  // Fires on startup (picks up persisted value) and after toolbar cycle changes.
   useEffect(() => {
     invoke("set_menu_theme", { theme });
   }, [theme]);
 
-  // Keep ref in sync so menu event listeners (registered once on mount) always
-  // see the current manifest rather than the stale closure value.
-  useEffect(() => { manifestRef.current = manifest; }, [manifest]);
-
-  async function handleClose() {
-    const m = manifestRef.current;
-    if (!m) return;
-    await invoke("close_document", { docId: m.doc_id });
-    await invoke("set_pdf_menus_enabled", { enabled: false });
-    setManifest(null);
-    useAppStore.getState().setActivePage(0);
-    useAppStore.getState().clearSelection();
-    useAppStore.getState().setIsDirty(false);
-    useAppStore.getState().setInfoPanelOpen(false);
+  async function handleCloseTab(docId: number) {
+    await invoke("close_document", { docId });
+    useAppStore.getState().removeTab(docId);
+    if (useAppStore.getState().tabs.length === 0) {
+      void invoke("set_pdf_menus_enabled", { enabled: false });
+      useAppStore.getState().setInfoPanelOpen(false);
+    }
   }
 
   function showError(message: string) {
@@ -96,11 +87,11 @@ function App() {
   }
 
   async function handleSave(path?: string) {
-    const m = manifestRef.current;
+    const m = activeTabRef.current;
     if (!m) return;
     const savePath = path ?? m.path;
     try {
-      await invoke("save_document", { docId: m.doc_id, path: savePath });
+      await invoke("save_document", { docId: m.docId, path: savePath });
       useAppStore.getState().setIsDirty(false);
     } catch (e) {
       showError(String(e));
@@ -113,22 +104,35 @@ function App() {
   }
 
   async function handleUndo() {
-    const m = manifestRef.current;
+    const m = activeTabRef.current;
     if (!m) return;
     try {
-      const next = await invoke<DocumentManifest>("undo_document", { docId: m.doc_id });
-      setManifest(next);
+      const next = await invoke<DocumentManifest>("undo_document", { docId: m.docId });
+      // Update the tab's canUndo/canRedo from the returned manifest
+      useAppStore.setState((s) => ({
+        tabs: s.tabs.map((t) =>
+          t.docId === next.doc_id
+            ? { ...t, canUndo: next.can_undo, canRedo: next.can_redo }
+            : t
+        ),
+      }));
     } catch (e) {
       showError(String(e));
     }
   }
 
   async function handleRedo() {
-    const m = manifestRef.current;
+    const m = activeTabRef.current;
     if (!m) return;
     try {
-      const next = await invoke<DocumentManifest>("redo_document", { docId: m.doc_id });
-      setManifest(next);
+      const next = await invoke<DocumentManifest>("redo_document", { docId: m.docId });
+      useAppStore.setState((s) => ({
+        tabs: s.tabs.map((t) =>
+          t.docId === next.doc_id
+            ? { ...t, canUndo: next.can_undo, canRedo: next.can_redo }
+            : t
+        ),
+      }));
     } catch (e) {
       showError(String(e));
     }
@@ -146,18 +150,16 @@ function App() {
   }
 
   async function handleOpenPath(path: string) {
-    setLoading(true);
-    const current = manifestRef.current;
-    if (current) {
-      await invoke("close_document", { docId: current.doc_id });
+    // Deduplicate: if already open, just switch to it
+    const existing = useAppStore.getState().tabs.find((t) => t.path === path);
+    if (existing) {
+      handleSwitchTab(existing.docId);
+      return;
     }
-    setManifest(null);
+    setLoading(true);
     try {
       const m = await invoke<DocumentManifest>("open_document", { path });
-      setManifest(m);
-      useAppStore.getState().setActivePage(0);
-      useAppStore.getState().clearSelection();
-      useAppStore.getState().setIsDirty(false);
+      useAppStore.getState().addTab(m);
       void invoke("set_pdf_menus_enabled", { enabled: true });
       useAppStore.getState().addRecentFile(path);
       void invoke("update_recent_menu", { paths: useAppStore.getState().recentFiles });
@@ -177,6 +179,36 @@ function App() {
     await handleOpenPath(path);
   }
 
+  function handleSwitchTab(docId: number) {
+    useAppStore.getState().setActiveDocId(docId);
+    // Scroll to the restored activePage after the virtualizer remounts
+    requestAnimationFrame(() => {
+      viewerRef.current?.scrollToPage(useAppStore.getState().activePage);
+    });
+  }
+
+  function navigateTabs(direction: 1 | -1) {
+    const { tabs, activeDocId } = useAppStore.getState();
+    if (tabs.length < 2) return;
+    const idx = tabs.findIndex((t) => t.docId === activeDocId);
+    if (idx === -1) return;
+    const next = tabs[(idx + direction + tabs.length) % tabs.length];
+    useAppStore.getState().setActiveDocId(next.docId);
+    requestAnimationFrame(() => {
+      viewerRef.current?.scrollToPage(useAppStore.getState().activePage);
+    });
+  }
+
+  function jumpToTab(n: number) {
+    const { tabs } = useAppStore.getState();
+    if (tabs.length === 0) return;
+    const target = tabs[Math.min(n - 1, tabs.length - 1)];
+    useAppStore.getState().setActiveDocId(target.docId);
+    requestAnimationFrame(() => {
+      viewerRef.current?.scrollToPage(useAppStore.getState().activePage);
+    });
+  }
+
   // Handle Mod+= for zoom in (mirrors the native menu's CmdOrCtrl+= shortcut).
   // Also handles ? (shortcut overlay) and Cmd+A (select all pages).
   useEffect(() => {
@@ -193,11 +225,24 @@ function App() {
         setShowShortcuts((v) => !v);
       }
       if ((e.metaKey || e.ctrlKey) && e.key === "a") {
-        const m = manifestRef.current;
+        const m = activeTabRef.current;
         if (m) {
           e.preventDefault();
-          useAppStore.getState().selectAll(m.page_count);
+          useAppStore.getState().selectAll(m.pageCount);
         }
+      }
+      // ⌘⇧] / ⌘⇧[ — next/prev tab (Mac; key is "}"/"}" because Shift+]/[ on US layout)
+      if (e.metaKey && e.key === "}") { e.preventDefault(); navigateTabs(1); }
+      if (e.metaKey && e.key === "{") { e.preventDefault(); navigateTabs(-1); }
+      // Ctrl+Tab / Ctrl+Shift+Tab — next/prev tab (Windows/Linux)
+      if (e.ctrlKey && !e.metaKey && e.key === "Tab") {
+        e.preventDefault();
+        if (e.shiftKey) navigateTabs(-1); else navigateTabs(1);
+      }
+      // ⌘1–⌘9 / Ctrl+1–9 — jump to nth tab; ⌘9 / Ctrl+9 goes to last tab
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key >= "1" && e.key <= "9") {
+        e.preventDefault();
+        jumpToTab(parseInt(e.key, 10));
       }
     }
     window.addEventListener("keydown", onKeyDown);
@@ -207,7 +252,10 @@ function App() {
   // Listen for native menu events forwarded from the Rust backend
   useEffect(() => {
     const unlistenOpen  = listen<void>("menu-open",  () => handleOpen());
-    const unlistenClose = listen<void>("menu-close", () => handleClose());
+    const unlistenClose = listen<void>("menu-close", () => {
+      const { activeDocId } = useAppStore.getState();
+      if (activeDocId !== null) void handleCloseTab(activeDocId);
+    });
     const unlistenTheme = listen<string>("menu-theme", (e) =>
       setTheme(e.payload as "light" | "dark" | "system")
     );
@@ -247,8 +295,8 @@ function App() {
     const unlistenUndo      = listen<void>("menu-undo",       () => handleUndo());
     const unlistenRedo      = listen<void>("menu-redo",       () => handleRedo());
     const unlistenSelectAll = listen<void>("menu-select-all", () => {
-      const m = manifestRef.current;
-      if (m) useAppStore.getState().selectAll(m.page_count);
+      const m = activeTabRef.current;
+      if (m) useAppStore.getState().selectAll(m.pageCount);
     });
     const unlistenPrint   = listen<void>("menu-print",   () => {
       toast.error("Print is not yet implemented.", { duration: 4000 });
@@ -260,6 +308,8 @@ function App() {
       useAppStore.getState().clearRecentFiles();
       void invoke("update_recent_menu", { paths: [] });
     });
+    const unlistenNextTab = listen<void>("menu-next-tab", () => navigateTabs(1));
+    const unlistenPrevTab  = listen<void>("menu-prev-tab",  () => navigateTabs(-1));
     return () => {
       unlistenOpen.then((fn) => fn());
       unlistenClose.then((fn) => fn());
@@ -285,9 +335,45 @@ function App() {
       unlistenPrint.then((fn) => fn());
       unlistenOpenRecent.then((fn) => fn());
       unlistenClearRecent.then((fn) => fn());
+      unlistenNextTab.then((fn) => fn());
+      unlistenPrevTab.then((fn) => fn());
     };
     // handleOpen is defined in render scope but only reads stable refs/setState.
     // Omitting from deps avoids re-registering listeners on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Drag-and-drop: open PDFs dropped onto the window.
+  // Use a ref for the unlisten function so the Strict Mode double-invoke
+  // cleanup fires correctly even before the promise resolves.
+  useEffect(() => {
+    const cancelRef = { fn: null as (() => void) | null };
+    const promise = getCurrentWebview().onDragDropEvent((event) => {
+      if (event.payload.type === "enter" && event.payload.paths.length > 0) setIsDragOver(true);
+      if (event.payload.type === "leave" || event.payload.type === "cancel") setIsDragOver(false);
+      if (event.payload.type === "drop") {
+        setIsDragOver(false);
+        for (const path of event.payload.paths) {
+          if (path.toLowerCase().endsWith(".pdf")) void handleOpenPath(path);
+        }
+      }
+    });
+    promise.then((fn) => {
+      // If cleanup already ran before this resolved, unregister immediately
+      if (cancelRef.fn === null) {
+        cancelRef.fn = fn;
+      } else {
+        fn();
+      }
+    });
+    return () => {
+      if (cancelRef.fn) {
+        cancelRef.fn();
+      } else {
+        // Mark as cancelled so the .then() above will immediately unregister
+        cancelRef.fn = () => {};
+      }
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -300,11 +386,11 @@ function App() {
       className="h-screen overflow-hidden"
       style={{ "--sidebar-width": `${sidebarWidth}px` } as React.CSSProperties}
     >
-      {manifest && (
+      {activeTab && (
         <Sidebar collapsible="offcanvas">
           <PageSidebar
-            docId={manifest.doc_id}
-            pageSizes={manifest.page_sizes}
+            docId={activeTab.docId}
+            pageSizes={activeTab.pageSizes}
             onScrollToPage={(i) => viewerRef.current?.scrollToPage(i)}
             onBugReport={openBugReportForError}
           />
@@ -315,10 +401,10 @@ function App() {
         <Toolbar
           onOpen={handleOpen}
           loading={loading}
-          hasDocument={manifest !== null}
+          hasDocument={activeTab !== null}
           isDirty={isDirty}
-          canUndo={manifest?.can_undo ?? false}
-          canRedo={manifest?.can_redo ?? false}
+          canUndo={activeTab?.canUndo ?? false}
+          canRedo={activeTab?.canRedo ?? false}
           onSave={handleSave}
           onUndo={handleUndo}
           onRedo={handleRedo}
@@ -326,27 +412,41 @@ function App() {
           onToggleInfo={toggleInfoPanel}
         />
 
+        {tabs.length > 0 && (
+          <TabBar
+            tabs={tabs}
+            activeDocId={activeDocId}
+            onSwitch={handleSwitchTab}
+            onClose={(docId) => void handleCloseTab(docId)}
+            onReorder={reorderTabs}
+          />
+        )}
+
         <Separator />
 
-        <div className="flex-1 overflow-hidden min-h-0">
-          {manifest ? (
+        <div className="relative flex-1 overflow-hidden min-h-0">
+          {activeTab ? (
             <PageViewer
+              key={activeDocId}
               ref={viewerRef}
-              docId={manifest.doc_id}
-              pageSizes={manifest.page_sizes}
+              docId={activeTab.docId}
+              pageSizes={activeTab.pageSizes}
             />
           ) : (
             <EmptyState onOpen={handleOpen} />
           )}
+          {isDragOver && (
+            <div className="absolute inset-0 ring-2 ring-blue-500 ring-inset bg-blue-500/10 pointer-events-none" />
+          )}
         </div>
 
-        <StatusBar pageCount={manifest?.page_count} />
+        <StatusBar pageCount={activeTab?.pageCount} />
       </SidebarInset>
 
-      {manifest && (
+      {activeTab && (
         <InfoPanel
-          docId={manifest.doc_id}
-          filename={manifest.filename}
+          docId={activeTab.docId}
+          filename={activeTab.filename}
           open={infoPanelOpen}
           onOpenChange={setInfoPanelOpen}
         />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/sidebar";
 import { useAppStore, ZOOM_STEPS, PageDisplay, TabEntry } from "@/store";
 import { useTheme } from "@/hooks/useTheme";
+import { useKeyboardNav } from "@/hooks/useKeyboardNav";
 import { platformName } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import type { DocumentManifest } from "@/types";
@@ -37,6 +38,7 @@ function App() {
   const viewerRef = useRef<PageViewerHandle>(null);
   // Stable ref for use inside event listener closures
   const activeTabRef = useRef<TabEntry | null>(null);
+  const sidebarRef = useRef<HTMLDivElement>(null);
 
   const tabs = useAppStore((s) => s.tabs);
   const activeDocId = useAppStore((s) => s.activeDocId);
@@ -52,6 +54,7 @@ function App() {
 
   // Apply theme (dark class on <html>) and keep it in sync with OS changes
   useTheme();
+  useKeyboardNav({ pageViewerRef: viewerRef, sidebarRef });
 
   // Keep ref in sync so event listeners always see the current active tab
   useEffect(() => { activeTabRef.current = activeTab; }, [activeTab]);
@@ -392,6 +395,7 @@ function App() {
             pageSizes={activeTab.pageSizes}
             onScrollToPage={(i) => viewerRef.current?.scrollToPage(i)}
             onBugReport={openBugReportForError}
+            containerRef={sidebarRef}
           />
         </Sidebar>
       )}

--- a/src/components/PageSidebar.tsx
+++ b/src/components/PageSidebar.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   SidebarContent,
@@ -18,6 +19,7 @@ interface Props {
   pageSizes: PageSize[];
   onScrollToPage(index: number): void;
   onBugReport(message: string): void;
+  containerRef?: RefObject<HTMLDivElement | null>;
 }
 
 /** Gap between thumbnails in pixels. */
@@ -32,32 +34,33 @@ const THUMBNAIL_GAP = 16;
  * width — including after the user resizes the window. The same ref drives
  * both the observer and the virtualizer's scroll container.
  */
-export function PageSidebar({ docId, pageSizes, onScrollToPage, onBugReport }: Props) {
-  const containerRef = useRef<HTMLDivElement>(null);
+export function PageSidebar({ docId, pageSizes, onScrollToPage, onBugReport, containerRef: externalRef }: Props) {
+  const internalRef = useRef<HTMLDivElement>(null);
+  const containerRef = externalRef ?? internalRef;
   const [thumbnailWidth, setThumbnailWidth] = useState(120);
-
-  // Range-select anchor — tracked in a ref to avoid re-renders.
-  const anchorRef = useRef(0);
 
   const selectedPages = useAppStore((s) => s.selectedPages);
   const togglePageSelection = useAppStore((s) => s.togglePageSelection);
   const selectPageRange = useAppStore((s) => s.selectPageRange);
   const clearSelection = useAppStore((s) => s.clearSelection);
+  const setSelectionAnchor = useAppStore((s) => s.setSelectionAnchor);
 
   const handleThumbClick = useCallback(
     (index: number, e: React.MouseEvent) => {
       if (e.metaKey || e.ctrlKey) {
+        const isAdding = !useAppStore.getState().selectedPages.has(index);
         togglePageSelection(index);
-        anchorRef.current = index;
+        if (isAdding) setSelectionAnchor(index);
       } else if (e.shiftKey) {
-        selectPageRange(anchorRef.current, index);
+        const anchor = useAppStore.getState().selectionAnchor ?? index;
+        selectPageRange(anchor, index);
       } else {
         clearSelection();
+        setSelectionAnchor(index);
         onScrollToPage(index);
-        anchorRef.current = index;
       }
     },
-    [togglePageSelection, selectPageRange, clearSelection, onScrollToPage]
+    [togglePageSelection, selectPageRange, clearSelection, setSelectionAnchor, onScrollToPage]
   );
 
   // Measure available content width and update thumbnails when it changes.

--- a/src/components/PageViewer.test.tsx
+++ b/src/components/PageViewer.test.tsx
@@ -112,6 +112,21 @@ describe("PageViewer — scrollToPage", () => {
 
     expect(useAppStore.getState().activePage).toBe(10); // page 11, NOT page 13 (index 12)
   });
+
+  it("scrollToPage sets scrollTop at the page's top edge including PAGE_TOP_GAP offset", async () => {
+    // At 75% zoom: pageWidth = round(612*75/100) = 459, rendered_h = round(792/612*459) = 594, slot = 610.
+    // Page 1 top in DOM = PAGE_TOP_GAP + slot0 = 16 + 610 = 626.
+    // scrollToPage(1) must set scrollTop = 626 so the page aligns to the viewport top.
+    const ref = createRef<PageViewerHandle>();
+    const { container } = render(<PageViewer ref={ref} docId={1} pageSizes={PAGES_5} />);
+    const scrollEl = container.firstElementChild as HTMLDivElement;
+
+    await act(async () => {
+      ref.current?.scrollToPage(1);
+    });
+
+    expect(scrollEl.scrollTop).toBe(626);
+  });
 });
 
 describe("PageViewer — natural scroll active page detection", () => {

--- a/src/components/PageViewer.tsx
+++ b/src/components/PageViewer.tsx
@@ -193,7 +193,7 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
       scrollToPage(index) {
         const el = parentRef.current;
         if (!el) return;
-        let offset = 0;
+        let offset = PAGE_TOP_GAP;
         for (let i = 0; i < index; i++) {
           const { width_pts, height_pts } = pageSizes[i];
           offset += Math.round((height_pts / width_pts) * pageWidthFor(width_pts)) + PAGE_GAP;

--- a/src/components/PageViewer.tsx
+++ b/src/components/PageViewer.tsx
@@ -21,6 +21,9 @@ export interface PageViewerHandle {
 /** Gap between pages in pixels. */
 const PAGE_GAP = 16;
 
+/** Extra space above the first page so content isn't cramped against the tab bar. */
+const PAGE_TOP_GAP = 28;
+
 /** Horizontal padding around pages in fit-width mode (16px each side). */
 const PAGE_PADDING_X = 32;
 
@@ -190,7 +193,7 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
       scrollToPage(index) {
         const el = parentRef.current;
         if (!el) return;
-        let offset = PAGE_GAP;
+        let offset = PAGE_TOP_GAP;
         for (let i = 0; i < index; i++) {
           const { width_pts, height_pts } = pageSizes[i];
           offset += Math.round((height_pts / width_pts) * pageWidthFor(width_pts)) + PAGE_GAP;
@@ -279,7 +282,7 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
       <div
         ref={parentRef}
         className={cn(
-          "h-full bg-zinc-200 dark:bg-zinc-800",
+          "h-full bg-muted",
           zoomMode === "fit-width" ? "overflow-y-auto" : "overflow-auto"
         )}
       >
@@ -287,7 +290,7 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
         <div
           className="relative w-full"
           style={{
-            height: virtualizer.getTotalSize() + PAGE_GAP,
+            height: virtualizer.getTotalSize() + PAGE_TOP_GAP,
             minWidth: manualContentWidth,
           }}
         >
@@ -305,7 +308,7 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
               <div
                 key={item.key}
                 className="absolute left-0 right-0"
-                style={{ top: item.start + PAGE_GAP, paddingBottom: PAGE_GAP }}
+                style={{ top: item.start + PAGE_TOP_GAP, paddingBottom: PAGE_GAP }}
               >
                 {/* mx-auto centers the page when it's narrower than the viewport. */}
                 <div style={{ width: pageWidth, margin: "0 auto" }}>

--- a/src/components/PageViewer.tsx
+++ b/src/components/PageViewer.tsx
@@ -21,8 +21,8 @@ export interface PageViewerHandle {
 /** Gap between pages in pixels. */
 const PAGE_GAP = 16;
 
-/** Extra space above the first page so content isn't cramped against the tab bar. */
-const PAGE_TOP_GAP = 28;
+/** Extra space above the first page — matches PAGE_GAP for visual consistency. */
+const PAGE_TOP_GAP = PAGE_GAP;
 
 /** Horizontal padding around pages in fit-width mode (16px each side). */
 const PAGE_PADDING_X = 32;
@@ -193,7 +193,7 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
       scrollToPage(index) {
         const el = parentRef.current;
         if (!el) return;
-        let offset = PAGE_TOP_GAP;
+        let offset = 0;
         for (let i = 0; i < index; i++) {
           const { width_pts, height_pts } = pageSizes[i];
           offset += Math.round((height_pts / width_pts) * pageWidthFor(width_pts)) + PAGE_GAP;

--- a/src/components/ShortcutOverlay.tsx
+++ b/src/components/ShortcutOverlay.tsx
@@ -11,30 +11,57 @@ interface Props {
   onClose(): void;
 }
 
-interface ShortcutRow {
+interface SingleRow {
   action: string;
   keys: string[];
 }
 
-interface Section {
-  label: string;
-  rows: ShortcutRow[];
+interface DualRow {
+  action: string;
+  standard: string | null;
+  vim: string | null;
 }
+
+interface SingleSection {
+  kind: "single";
+  label: string;
+  rows: SingleRow[];
+}
+
+interface DualSection {
+  kind: "dual";
+  label: string;
+  rows: DualRow[];
+}
+
+type Section = SingleSection | DualSection;
 
 function buildSections(): Section[] {
   const mod = modKey();
   const shiftMod = shiftModKey();
   return [
     {
+      kind: "single",
       label: "File",
       rows: [
-        { action: "Open PDF",  keys: [`${mod}O`] },
-        { action: "Save",      keys: [`${mod}S`] },
-        { action: "Save As",   keys: [`${shiftMod}S`] },
-        { action: "Close",     keys: [`${mod}W`] },
+        { action: "Open PDF", keys: [`${mod}O`] },
+        { action: "Save",     keys: [`${mod}S`] },
+        { action: "Save As",  keys: [`${shiftMod}S`] },
+        { action: "Close",    keys: [`${mod}W`] },
       ],
     },
     {
+      kind: "dual",
+      label: "Page Navigation",
+      rows: [
+        { action: "Next page",     standard: "PgDn", vim: "j" },
+        { action: "Previous page", standard: "PgUp",  vim: "k" },
+        { action: "First page",    standard: "Home",  vim: "gg" },
+        { action: "Last page",     standard: "End",   vim: "G" },
+      ],
+    },
+    {
+      kind: "single",
       label: "View",
       rows: [
         { action: "Document Info",  keys: [`${mod}I`] },
@@ -45,7 +72,8 @@ function buildSections(): Section[] {
       ],
     },
     {
-      label: "Navigation",
+      kind: "single",
+      label: "Tabs",
       rows: [
         {
           action: "Next Tab",
@@ -62,18 +90,82 @@ function buildSections(): Section[] {
       ],
     },
     {
+      kind: "dual",
       label: "Selection",
       rows: [
-        { action: "Select All Pages", keys: [`${mod}A`] },
+        { action: "Select All",    standard: `${mod}A`, vim: null },
+        { action: "Expand down",   standard: "⇧↓",      vim: "⇧j" },
+        { action: "Expand up",     standard: "⇧↑",      vim: "⇧k" },
       ],
     },
     {
+      kind: "single",
       label: "Help",
       rows: [
         { action: "Keyboard Shortcuts", keys: ["?"] },
       ],
     },
   ];
+}
+
+function Kbd({ children }: { children: string }) {
+  return (
+    <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-xs">
+      {children}
+    </kbd>
+  );
+}
+
+function SingleSectionView({ section }: { section: SingleSection }) {
+  return (
+    <div>
+      <p className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {section.label}
+      </p>
+      <div className="space-y-1">
+        {section.rows.map((row) => (
+          <div key={row.action} className="flex items-center justify-between text-sm">
+            <span>{row.action}</span>
+            <div className="flex items-center gap-1">
+              {row.keys.map((k) => <Kbd key={k}>{k}</Kbd>)}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DualSectionView({ section }: { section: DualSection }) {
+  return (
+    <div>
+      <p className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {section.label}
+      </p>
+      {/* Column headers */}
+      <div className="mb-1 grid grid-cols-[1fr_88px_56px] gap-x-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+        <span />
+        <span className="text-right">Standard</span>
+        <span className="text-right">Vim</span>
+      </div>
+      <div className="space-y-1">
+        {section.rows.map((row) => (
+          <div
+            key={row.action}
+            className="grid grid-cols-[1fr_88px_56px] items-center gap-x-2 text-sm"
+          >
+            <span>{row.action}</span>
+            <div className="flex justify-end">
+              {row.standard ? <Kbd>{row.standard}</Kbd> : <span className="text-muted-foreground/40">—</span>}
+            </div>
+            <div className="flex justify-end">
+              {row.vim ? <Kbd>{row.vim}</Kbd> : <span className="text-muted-foreground/40">—</span>}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 export function ShortcutOverlay({ open, onClose }: Props) {
@@ -87,30 +179,13 @@ export function ShortcutOverlay({ open, onClose }: Props) {
         </DialogHeader>
 
         <div className="mt-2 space-y-5">
-          {sections.map((section) => (
-            <div key={section.label}>
-              <p className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                {section.label}
-              </p>
-              <div className="space-y-1">
-                {section.rows.map((row) => (
-                  <div key={row.action} className="flex items-center justify-between text-sm">
-                    <span>{row.action}</span>
-                    <div className="flex items-center gap-1">
-                      {row.keys.map((k) => (
-                        <kbd
-                          key={k}
-                          className="rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-xs"
-                        >
-                          {k}
-                        </kbd>
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ))}
+          {sections.map((section) =>
+            section.kind === "dual" ? (
+              <DualSectionView key={section.label} section={section} />
+            ) : (
+              <SingleSectionView key={section.label} section={section} />
+            )
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/ShortcutOverlay.tsx
+++ b/src/components/ShortcutOverlay.tsx
@@ -4,7 +4,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { modKey, shiftModKey } from "@/lib/platform";
+import { isMac, modKey, shiftModKey } from "@/lib/platform";
 
 interface Props {
   open: boolean;
@@ -42,6 +42,23 @@ function buildSections(): Section[] {
         { action: "Zoom Out",       keys: [`${mod}−`] },
         { action: "Fit Width",      keys: [`${mod}0`] },
         { action: "Toggle Sidebar", keys: [`${mod}B`] },
+      ],
+    },
+    {
+      label: "Navigation",
+      rows: [
+        {
+          action: "Next Tab",
+          keys: isMac ? ["⌘⇧]"] : ["Ctrl+Tab", "Ctrl+PgDn"],
+        },
+        {
+          action: "Previous Tab",
+          keys: isMac ? ["⌘⇧["] : ["Ctrl+Shift+Tab", "Ctrl+PgUp"],
+        },
+        {
+          action: "Jump to Tab",
+          keys: [`${mod}1 – ${mod}9`],
+        },
       ],
     },
     {

--- a/src/components/ShortcutOverlay.tsx
+++ b/src/components/ShortcutOverlay.tsx
@@ -143,6 +143,7 @@ function DualSectionView({ section }: { section: DualSection }) {
         {section.label}
       </p>
       {/* Column headers */}
+      {/* grid-cols must match data row below */}
       <div className="mb-1 grid grid-cols-[1fr_88px_56px] gap-x-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
         <span />
         <span className="text-right">Standard</span>
@@ -154,6 +155,7 @@ function DualSectionView({ section }: { section: DualSection }) {
             key={row.action}
             className="grid grid-cols-[1fr_88px_56px] items-center gap-x-2 text-sm"
           >
+            {/* grid-cols must match header row above */}
             <span>{row.action}</span>
             <div className="flex justify-end">
               {row.standard ? <Kbd>{row.standard}</Kbd> : <span className="text-muted-foreground/40">—</span>}

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -1,0 +1,198 @@
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { TabBar } from "./TabBar";
+import type { TabEntry } from "@/store";
+import type { DragEndEvent } from "@dnd-kit/core";
+
+// Capture the onDragEnd handler so tests can invoke it directly
+let capturedOnDragEnd: ((event: DragEndEvent) => void) | undefined;
+
+vi.mock("@dnd-kit/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@dnd-kit/core")>();
+  return {
+    ...actual,
+    DndContext: ({
+      children,
+      onDragEnd,
+    }: {
+      children: React.ReactNode;
+      onDragEnd?: (event: DragEndEvent) => void;
+    }) => {
+      capturedOnDragEnd = onDragEnd;
+      return <>{children}</>;
+    },
+  };
+});
+
+const TAB_A: TabEntry = {
+  docId: 1,
+  filename: "alpha.pdf",
+  path: "/alpha.pdf",
+  pageCount: 2,
+  pageSizes: [],
+  canUndo: false,
+  canRedo: false,
+  isDirty: false,
+};
+
+const TAB_B: TabEntry = {
+  docId: 2,
+  filename: "beta.pdf",
+  path: "/beta.pdf",
+  pageCount: 5,
+  pageSizes: [],
+  canUndo: false,
+  canRedo: false,
+  isDirty: false,
+};
+
+describe("TabBar", () => {
+  it("renders a tab for each entry", () => {
+    render(
+      <TabBar tabs={[TAB_A, TAB_B]} activeDocId={1} onSwitch={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(screen.getByText("alpha.pdf")).toBeInTheDocument();
+    expect(screen.getByText("beta.pdf")).toBeInTheDocument();
+  });
+
+  it("marks only the active tab with aria-selected=true", () => {
+    render(
+      <TabBar tabs={[TAB_A, TAB_B]} activeDocId={1} onSwitch={vi.fn()} onClose={vi.fn()} />
+    );
+    const tabs = screen.getAllByRole("tab");
+    const alphaTab = tabs.find((t) => t.textContent?.includes("alpha.pdf"))!;
+    const betaTab = tabs.find((t) => t.textContent?.includes("beta.pdf"))!;
+    expect(alphaTab).toHaveAttribute("aria-selected", "true");
+    expect(betaTab).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("calls onSwitch with the correct docId when a tab body is clicked", async () => {
+    const onSwitch = vi.fn();
+    render(
+      <TabBar tabs={[TAB_A, TAB_B]} activeDocId={1} onSwitch={onSwitch} onClose={vi.fn()} />
+    );
+    await userEvent.click(screen.getByText("beta.pdf"));
+    expect(onSwitch).toHaveBeenCalledWith(2);
+  });
+
+  it("calls onClose with the correct docId when the close button is clicked", async () => {
+    const onClose = vi.fn();
+    render(
+      <TabBar tabs={[TAB_A, TAB_B]} activeDocId={1} onSwitch={vi.fn()} onClose={onClose} />
+    );
+    await userEvent.click(screen.getByRole("button", { name: /close beta\.pdf/i }));
+    expect(onClose).toHaveBeenCalledWith(2);
+  });
+
+  it("close button click does not also fire onSwitch", async () => {
+    const onSwitch = vi.fn();
+    render(
+      <TabBar tabs={[TAB_A, TAB_B]} activeDocId={1} onSwitch={onSwitch} onClose={vi.fn()} />
+    );
+    await userEvent.click(screen.getByRole("button", { name: /close beta\.pdf/i }));
+    expect(onSwitch).not.toHaveBeenCalled();
+  });
+
+  it("renders dirty dot when tab.isDirty is true", () => {
+    const dirtyTab = { ...TAB_A, isDirty: true };
+    render(
+      <TabBar tabs={[dirtyTab]} activeDocId={1} onSwitch={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(screen.getByLabelText("unsaved changes")).toBeInTheDocument();
+  });
+
+  it("does not render dirty dot when tab.isDirty is false", () => {
+    render(
+      <TabBar tabs={[TAB_A]} activeDocId={1} onSwitch={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(screen.queryByLabelText("unsaved changes")).not.toBeInTheDocument();
+  });
+
+  it("close button has accessible label including filename", () => {
+    render(
+      <TabBar tabs={[TAB_A]} activeDocId={1} onSwitch={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(screen.getByRole("button", { name: /close alpha\.pdf/i })).toBeInTheDocument();
+  });
+
+  it("middle-truncates filenames longer than 24 characters", () => {
+    const longTab = { ...TAB_A, filename: "very-long-document-name-here.pdf" };
+    render(
+      <TabBar tabs={[longTab]} activeDocId={1} onSwitch={vi.fn()} onClose={vi.fn()} />
+    );
+    const displayed = screen.getByTitle("very-long-document-name-here.pdf").textContent!;
+    expect(displayed.length).toBeLessThanOrEqual(24);
+    expect(displayed).toContain("…");
+    expect(displayed.endsWith(".pdf")).toBe(true);
+  });
+
+  it("renders nothing when tabs array is empty", () => {
+    const { container } = render(
+      <TabBar tabs={[]} activeDocId={null} onSwitch={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  describe("tab reordering", () => {
+    it("calls onReorder with correct indices when drag ends on a different tab", () => {
+      const onReorder = vi.fn();
+      render(
+        <TabBar
+          tabs={[TAB_A, TAB_B]}
+          activeDocId={1}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onReorder={onReorder}
+        />
+      );
+      act(() => {
+        capturedOnDragEnd?.({
+          active: { id: TAB_A.docId },
+          over: { id: TAB_B.docId },
+        } as DragEndEvent);
+      });
+      expect(onReorder).toHaveBeenCalledWith(0, 1);
+    });
+
+    it("does not call onReorder when dropped on the same tab", () => {
+      const onReorder = vi.fn();
+      render(
+        <TabBar
+          tabs={[TAB_A, TAB_B]}
+          activeDocId={1}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onReorder={onReorder}
+        />
+      );
+      act(() => {
+        capturedOnDragEnd?.({
+          active: { id: TAB_A.docId },
+          over: { id: TAB_A.docId },
+        } as DragEndEvent);
+      });
+      expect(onReorder).not.toHaveBeenCalled();
+    });
+
+    it("does not call onReorder when dropped outside any tab", () => {
+      const onReorder = vi.fn();
+      render(
+        <TabBar
+          tabs={[TAB_A, TAB_B]}
+          activeDocId={1}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onReorder={onReorder}
+        />
+      );
+      act(() => {
+        capturedOnDragEnd?.({
+          active: { id: TAB_A.docId },
+          over: null,
+        } as DragEndEvent);
+      });
+      expect(onReorder).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,0 +1,117 @@
+import { X } from "lucide-react";
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  horizontalListSortingStrategy,
+  useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { cn } from "@/lib/utils";
+import { middleTruncate } from "@/lib/truncate";
+import type { TabEntry } from "@/store";
+
+interface TabBarProps {
+  tabs: TabEntry[];
+  activeDocId: number | null;
+  onSwitch(docId: number): void;
+  onClose(docId: number): void;
+  onReorder?: (fromIndex: number, toIndex: number) => void;
+}
+
+interface SortableTabProps {
+  tab: TabEntry;
+  isActive: boolean;
+  onSwitch(docId: number): void;
+  onClose(docId: number): void;
+}
+
+function SortableTab({ tab, isActive, onSwitch, onClose }: SortableTabProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: tab.docId });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : undefined,
+  };
+
+  return (
+    <button
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      role="tab"
+      aria-selected={isActive}
+      tabIndex={isActive ? 0 : -1}
+      onClick={() => onSwitch(tab.docId)}
+      className={cn(
+        "flex items-center gap-1.5 px-3 h-full text-sm whitespace-nowrap border-r border-border/50 select-none cursor-grab active:cursor-grabbing",
+        isActive
+          ? "bg-background text-foreground border-b-2 border-b-primary -mb-px"
+          : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+      )}
+    >
+      {tab.isDirty && (
+        <span aria-label="unsaved changes" className="size-1.5 rounded-full bg-amber-400 shrink-0" />
+      )}
+      <span title={tab.filename}>{middleTruncate(tab.filename, 24)}</span>
+      <button
+        type="button"
+        aria-label={`Close ${tab.filename}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClose(tab.docId);
+        }}
+        className="ml-0.5 rounded-sm p-0.5 hover:bg-muted-foreground/20 shrink-0"
+      >
+        <X className="size-3" />
+      </button>
+    </button>
+  );
+}
+
+export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabBarProps) {
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
+
+  if (tabs.length === 0) return null;
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const fromIndex = tabs.findIndex((t) => t.docId === active.id);
+    const toIndex = tabs.findIndex((t) => t.docId === over.id);
+    if (fromIndex !== -1 && toIndex !== -1) {
+      onReorder?.(fromIndex, toIndex);
+    }
+  }
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={tabs.map((t) => t.docId)} strategy={horizontalListSortingStrategy}>
+        <div
+          role="tablist"
+          aria-label="Open documents"
+          className="flex h-8 shrink-0 overflow-x-auto border-b bg-muted/30"
+        >
+          {tabs.map((tab) => (
+            <SortableTab
+              key={tab.docId}
+              tab={tab}
+              isActive={tab.docId === activeDocId}
+              onSwitch={onSwitch}
+              onClose={onClose}
+            />
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -10,7 +10,7 @@ import {
   type DragEndEvent,
   type DragStartEvent,
 } from "@dnd-kit/core";
-import { restrictToHorizontalAxis } from "@dnd-kit/modifiers";
+import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
 import {
   SortableContext,
   horizontalListSortingStrategy,
@@ -59,17 +59,23 @@ function SortableTab({ tab, isActive, onSwitch, onClose }: SortableTabProps) {
   };
 
   return (
-    <button
+    <div
       ref={setNodeRef}
       style={style}
       {...attributes}
       {...listeners}
       role="tab"
       aria-selected={isActive}
-      tabIndex={isActive ? 0 : -1}
+      tabIndex={0}
       onClick={() => onSwitch(tab.docId)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSwitch(tab.docId);
+        }
+      }}
       className={cn(
-        "inline-flex items-center gap-1.5 px-3 h-7 text-sm font-medium whitespace-nowrap border-t-2 select-none cursor-grab active:cursor-grabbing transition-colors",
+        "inline-flex items-center gap-1.5 px-3.5 h-8 text-sm font-medium whitespace-nowrap border-t-2 select-none cursor-grab active:cursor-grabbing transition-colors",
         isDragging && "opacity-0",
         isActive
           ? "bg-muted text-foreground border-primary"
@@ -80,15 +86,16 @@ function SortableTab({ tab, isActive, onSwitch, onClose }: SortableTabProps) {
       <button
         type="button"
         aria-label={`Close ${tab.filename}`}
+        onPointerDown={(e) => e.stopPropagation()}
         onClick={(e) => {
           e.stopPropagation();
           onClose(tab.docId);
         }}
-        className="ml-0.5 rounded-sm p-0.5 hover:bg-muted-foreground/20 shrink-0"
+        className="ml-0.5 rounded-sm p-0.5 hover:bg-muted-foreground/30 shrink-0 cursor-default"
       >
         <X className="size-3" />
       </button>
-    </button>
+    </div>
   );
 }
 
@@ -123,7 +130,7 @@ export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabB
     <DndContext
       sensors={sensors}
       collisionDetection={closestCenter}
-      modifiers={[restrictToHorizontalAxis]}
+      modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
@@ -132,7 +139,7 @@ export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabB
         <div
           role="tablist"
           aria-label="Open documents"
-          className="flex shrink-0 overflow-x-auto items-end bg-background pt-1 px-2 gap-[3px]"
+          className="flex shrink-0 overflow-x-auto items-end bg-background border-t border-border pt-1.5 px-2 gap-1"
         >
           {tabs.map((tab) => (
             <SortableTab
@@ -148,7 +155,7 @@ export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabB
 
       <DragOverlay dropAnimation={null}>
         {activeTab && (
-          <div className="inline-flex items-center gap-1.5 px-3 h-7 text-sm font-medium whitespace-nowrap border-t-2 bg-tab-inactive text-muted-foreground border-transparent cursor-grabbing shadow-md">
+          <div className="inline-flex items-center gap-1.5 px-3.5 h-8 text-sm font-medium whitespace-nowrap border-t-2 bg-muted text-foreground border-primary cursor-grabbing shadow-lg">
             <TabContent tab={activeTab} />
             <span className="ml-0.5 p-0.5">
               <X className="size-3" />

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,12 +1,16 @@
+import { useState } from "react";
 import { X } from "lucide-react";
 import {
   DndContext,
+  DragOverlay,
   PointerSensor,
   useSensor,
   useSensors,
   closestCenter,
   type DragEndEvent,
+  type DragStartEvent,
 } from "@dnd-kit/core";
+import { restrictToHorizontalAxis } from "@dnd-kit/modifiers";
 import {
   SortableContext,
   horizontalListSortingStrategy,
@@ -32,14 +36,26 @@ interface SortableTabProps {
   onClose(docId: number): void;
 }
 
+/** Shared tab content — rendered both in SortableTab and DragOverlay. */
+function TabContent({ tab }: { tab: TabEntry }) {
+  return (
+    <>
+      {tab.isDirty && (
+        <span aria-label="unsaved changes" className="size-1.5 rounded-full bg-amber-400 shrink-0" />
+      )}
+      <span title={tab.filename}>{middleTruncate(tab.filename, 24)}</span>
+      {/* Close button is rendered separately in SortableTab; omitted here intentionally */}
+    </>
+  );
+}
+
 function SortableTab({ tab, isActive, onSwitch, onClose }: SortableTabProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: tab.docId });
 
   const style = {
-    transform: CSS.Transform.toString(transform),
+    transform: CSS.Translate.toString(transform),
     transition,
-    opacity: isDragging ? 0.5 : undefined,
   };
 
   return (
@@ -53,16 +69,14 @@ function SortableTab({ tab, isActive, onSwitch, onClose }: SortableTabProps) {
       tabIndex={isActive ? 0 : -1}
       onClick={() => onSwitch(tab.docId)}
       className={cn(
-        "flex items-center gap-1.5 px-3 h-full text-sm whitespace-nowrap border-r border-border/50 select-none cursor-grab active:cursor-grabbing",
+        "inline-flex items-center gap-1.5 px-3 h-7 text-sm font-medium whitespace-nowrap border-t-2 select-none cursor-grab active:cursor-grabbing transition-colors",
+        isDragging && "opacity-0",
         isActive
-          ? "bg-background text-foreground border-b-2 border-b-primary -mb-px"
-          : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+          ? "bg-muted text-foreground border-primary"
+          : "bg-tab-inactive text-muted-foreground border-transparent hover:bg-muted hover:text-foreground"
       )}
     >
-      {tab.isDirty && (
-        <span aria-label="unsaved changes" className="size-1.5 rounded-full bg-amber-400 shrink-0" />
-      )}
-      <span title={tab.filename}>{middleTruncate(tab.filename, 24)}</span>
+      <TabContent tab={tab} />
       <button
         type="button"
         aria-label={`Close ${tab.filename}`}
@@ -79,11 +93,19 @@ function SortableTab({ tab, isActive, onSwitch, onClose }: SortableTabProps) {
 }
 
 export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabBarProps) {
+  const [activeId, setActiveId] = useState<number | null>(null);
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
 
   if (tabs.length === 0) return null;
 
+  const activeTab = activeId !== null ? tabs.find((t) => t.docId === activeId) : null;
+
+  function handleDragStart(event: DragStartEvent) {
+    setActiveId(event.active.id as number);
+  }
+
   function handleDragEnd(event: DragEndEvent) {
+    setActiveId(null);
     const { active, over } = event;
     if (!over || active.id === over.id) return;
     const fromIndex = tabs.findIndex((t) => t.docId === active.id);
@@ -93,13 +115,24 @@ export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabB
     }
   }
 
+  function handleDragCancel() {
+    setActiveId(null);
+  }
+
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      modifiers={[restrictToHorizontalAxis]}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
       <SortableContext items={tabs.map((t) => t.docId)} strategy={horizontalListSortingStrategy}>
         <div
           role="tablist"
           aria-label="Open documents"
-          className="flex h-8 shrink-0 overflow-x-auto border-b bg-muted/30"
+          className="flex shrink-0 overflow-x-auto items-end bg-background pt-1 px-2 gap-[3px]"
         >
           {tabs.map((tab) => (
             <SortableTab
@@ -112,6 +145,17 @@ export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabB
           ))}
         </div>
       </SortableContext>
+
+      <DragOverlay dropAnimation={null}>
+        {activeTab && (
+          <div className="inline-flex items-center gap-1.5 px-3 h-7 text-sm font-medium whitespace-nowrap border-t-2 bg-tab-inactive text-muted-foreground border-transparent cursor-grabbing shadow-md">
+            <TabContent tab={activeTab} />
+            <span className="ml-0.5 p-0.5">
+              <X className="size-3" />
+            </span>
+          </div>
+        )}
+      </DragOverlay>
     </DndContext>
   );
 }

--- a/src/hooks/useKeyboardNav.test.ts
+++ b/src/hooks/useKeyboardNav.test.ts
@@ -54,6 +54,16 @@ describe("page navigation — no document open", () => {
     fireKey("j");
     expect(scrollToPage).not.toHaveBeenCalled();
   });
+
+  it("does not call scrollToPage when pageCount is 0", () => {
+    useAppStore.setState({
+      tabs: [{ ...useAppStore.getState().tabs[0], pageCount: 0 }],
+    });
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("j");
+    expect(scrollToPage).not.toHaveBeenCalled();
+  });
 });
 
 describe("page navigation — input guard", () => {

--- a/src/hooks/useKeyboardNav.test.ts
+++ b/src/hooks/useKeyboardNav.test.ts
@@ -1,0 +1,249 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useKeyboardNav } from "./useKeyboardNav";
+import { useAppStore } from "@/store";
+import type { DocumentManifest } from "@/types";
+
+// Minimal tab fixture
+const MANIFEST: DocumentManifest = {
+  doc_id: 1,
+  filename: "test.pdf",
+  path: "/test.pdf",
+  page_count: 10,
+  page_sizes: [],
+  can_undo: false,
+  can_redo: false,
+};
+
+function fireKey(key: string, extra: Partial<KeyboardEventInit> = {}) {
+  window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...extra }));
+}
+
+function makeRefs(sidebarEl?: HTMLElement | null) {
+  const scrollToPage = vi.fn();
+  const pageViewerRef = { current: { scrollToPage } } as any;
+  const sidebarRef = { current: sidebarEl ?? null } as any;
+  return { scrollToPage, pageViewerRef, sidebarRef };
+}
+
+beforeEach(() => {
+  useAppStore.setState({
+    tabs: [],
+    activeDocId: null,
+    docViewStates: new Map(),
+    activePage: 0,
+    zoom: 75,
+    zoomMode: "manual",
+    selectedPages: new Set(),
+    isDirty: false,
+    selectionAnchor: null,
+  });
+  useAppStore.getState().addTab(MANIFEST);
+  useAppStore.setState({ activePage: 5 }); // start mid-document
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("page navigation — no document open", () => {
+  it("does not call scrollToPage when activeDocId is null", () => {
+    useAppStore.setState({ activeDocId: null });
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("j");
+    expect(scrollToPage).not.toHaveBeenCalled();
+  });
+});
+
+describe("page navigation — input guard", () => {
+  it("does not fire when target is an <input>", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    // Dispatch from the input so e.target is naturally set to it and it bubbles to window
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "j", bubbles: true }));
+    expect(scrollToPage).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+  });
+});
+
+describe("j / PageDown — next page", () => {
+  it("j scrolls to activePage + 1", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("j");
+    expect(scrollToPage).toHaveBeenCalledWith(6);
+  });
+
+  it("PageDown scrolls to activePage + 1", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("PageDown");
+    expect(scrollToPage).toHaveBeenCalledWith(6);
+  });
+
+  it("j clamps at last page", () => {
+    useAppStore.setState({ activePage: 9 }); // last page (pageCount=10)
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("j");
+    expect(scrollToPage).toHaveBeenCalledWith(9);
+  });
+});
+
+describe("k / PageUp — previous page", () => {
+  it("k scrolls to activePage - 1", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("k");
+    expect(scrollToPage).toHaveBeenCalledWith(4);
+  });
+
+  it("PageUp scrolls to activePage - 1", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("PageUp");
+    expect(scrollToPage).toHaveBeenCalledWith(4);
+  });
+
+  it("k clamps at first page", () => {
+    useAppStore.setState({ activePage: 0 });
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("k");
+    expect(scrollToPage).toHaveBeenCalledWith(0);
+  });
+});
+
+describe("G / End — last page", () => {
+  it("G jumps to last page", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("G");
+    expect(scrollToPage).toHaveBeenCalledWith(9);
+  });
+
+  it("End jumps to last page", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("End");
+    expect(scrollToPage).toHaveBeenCalledWith(9);
+  });
+});
+
+describe("Home — first page", () => {
+  it("Home jumps to first page", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("Home");
+    expect(scrollToPage).toHaveBeenCalledWith(0);
+  });
+});
+
+describe("gg — first page", () => {
+  it("two g presses within 500ms jump to first page", () => {
+    vi.useFakeTimers();
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("g");
+    vi.advanceTimersByTime(400);
+    fireKey("g");
+    expect(scrollToPage).toHaveBeenCalledWith(0);
+  });
+
+  it("two g presses more than 500ms apart do not jump", () => {
+    vi.useFakeTimers();
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("g");
+    vi.advanceTimersByTime(501);
+    fireKey("g");
+    expect(scrollToPage).not.toHaveBeenCalled();
+  });
+
+  it("single g press does not jump", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("g");
+    expect(scrollToPage).not.toHaveBeenCalled();
+  });
+});
+
+describe("selection expansion — sidebar guard", () => {
+  function makeSidebarSetup() {
+    const sidebarEl = document.createElement("div");
+    document.body.appendChild(sidebarEl);
+    const child = document.createElement("button");
+    child.setAttribute("tabindex", "0");
+    sidebarEl.appendChild(child);
+    child.focus();
+    return { sidebarEl, cleanup: () => document.body.removeChild(sidebarEl) };
+  }
+
+  it("J (Shift+j) does not fire when sidebar not focused", () => {
+    const { pageViewerRef, sidebarRef } = makeRefs(null);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ selectionAnchor: 5 });
+    fireKey("J");
+    expect(useAppStore.getState().selectedPages.size).toBe(0);
+  });
+
+  it("J (Shift+j) expands selection down when sidebar focused", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 5, selectionAnchor: 5 });
+    fireKey("J");
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([5, 6]);
+    expect(useAppStore.getState().activePage).toBe(6);
+    cleanup();
+  });
+
+  it("K (Shift+k) expands selection up when sidebar focused", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 5, selectionAnchor: 5 });
+    fireKey("K");
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([4, 5]);
+    expect(useAppStore.getState().activePage).toBe(4);
+    cleanup();
+  });
+
+  it("Shift+ArrowDown expands selection down when sidebar focused", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 5, selectionAnchor: 5 });
+    fireKey("ArrowDown", { shiftKey: true });
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([5, 6]);
+    cleanup();
+  });
+
+  it("Shift+ArrowUp expands selection up when sidebar focused", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 5, selectionAnchor: 5 });
+    fireKey("ArrowUp", { shiftKey: true });
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([4, 5]);
+    cleanup();
+  });
+
+  it("selection expansion uses activePage as fallback anchor when selectionAnchor is null", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 3, selectionAnchor: null });
+    fireKey("J");
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([3, 4]);
+    cleanup();
+  });
+});

--- a/src/hooks/useKeyboardNav.ts
+++ b/src/hooks/useKeyboardNav.ts
@@ -59,14 +59,14 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
       }
 
       // j — next page
-      if (e.key === "j" && !e.metaKey && !e.ctrlKey) {
+      if (e.key === "j" && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
         pageViewerRef.current?.scrollToPage(Math.min(activePage + 1, pageCount - 1));
         return;
       }
 
       // k — previous page
-      if (e.key === "k" && !e.metaKey && !e.ctrlKey) {
+      if (e.key === "k" && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
         pageViewerRef.current?.scrollToPage(Math.max(activePage - 1, 0));
         return;
@@ -76,11 +76,10 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
       if (e.key === "J" && !e.metaKey && !e.ctrlKey) {
         if (!sidebarFocused) return;
         e.preventDefault();
-        const { selectionAnchor } = useAppStore.getState();
-        const anchor = selectionAnchor ?? activePage;
+        const anchor = state.selectionAnchor ?? activePage;
         const cursor = Math.min(activePage + 1, pageCount - 1);
-        useAppStore.getState().setActivePage(cursor);
-        useAppStore.getState().selectPageRange(anchor, cursor);
+        state.setActivePage(cursor);
+        state.selectPageRange(anchor, cursor);
         return;
       }
 
@@ -88,11 +87,10 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
       if (e.key === "K" && !e.metaKey && !e.ctrlKey) {
         if (!sidebarFocused) return;
         e.preventDefault();
-        const { selectionAnchor } = useAppStore.getState();
-        const anchor = selectionAnchor ?? activePage;
+        const anchor = state.selectionAnchor ?? activePage;
         const cursor = Math.max(activePage - 1, 0);
-        useAppStore.getState().setActivePage(cursor);
-        useAppStore.getState().selectPageRange(anchor, cursor);
+        state.setActivePage(cursor);
+        state.selectPageRange(anchor, cursor);
         return;
       }
 
@@ -128,11 +126,10 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
       if (e.key === "ArrowDown" && e.shiftKey && !e.metaKey && !e.ctrlKey) {
         if (!sidebarFocused) return;
         e.preventDefault();
-        const { selectionAnchor } = useAppStore.getState();
-        const anchor = selectionAnchor ?? activePage;
+        const anchor = state.selectionAnchor ?? activePage;
         const cursor = Math.min(activePage + 1, pageCount - 1);
-        useAppStore.getState().setActivePage(cursor);
-        useAppStore.getState().selectPageRange(anchor, cursor);
+        state.setActivePage(cursor);
+        state.selectPageRange(anchor, cursor);
         return;
       }
 
@@ -140,11 +137,10 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
       if (e.key === "ArrowUp" && e.shiftKey && !e.metaKey && !e.ctrlKey) {
         if (!sidebarFocused) return;
         e.preventDefault();
-        const { selectionAnchor } = useAppStore.getState();
-        const anchor = selectionAnchor ?? activePage;
+        const anchor = state.selectionAnchor ?? activePage;
         const cursor = Math.max(activePage - 1, 0);
-        useAppStore.getState().setActivePage(cursor);
-        useAppStore.getState().selectPageRange(anchor, cursor);
+        state.setActivePage(cursor);
+        state.selectPageRange(anchor, cursor);
         return;
       }
     }

--- a/src/hooks/useKeyboardNav.ts
+++ b/src/hooks/useKeyboardNav.ts
@@ -1,0 +1,155 @@
+import { useEffect, useRef } from "react";
+import type { RefObject } from "react";
+import { useAppStore } from "@/store";
+import type { PageViewerHandle } from "@/components/PageViewer";
+
+interface Options {
+  pageViewerRef: RefObject<PageViewerHandle | null>;
+  sidebarRef: RefObject<HTMLElement | null>;
+}
+
+function isInputFocused(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    target.contentEditable === "true"
+  );
+}
+
+export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
+  const lastGRef = useRef<number>(0);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (isInputFocused(e.target)) return;
+
+      const state = useAppStore.getState();
+      if (state.activeDocId === null) return;
+
+      const tab = state.tabs.find((t) => t.docId === state.activeDocId);
+      if (!tab || tab.pageCount === 0) return;
+
+      const { activePage } = state;
+      const pageCount = tab.pageCount;
+      const sidebarFocused =
+        sidebarRef.current != null &&
+        sidebarRef.current.contains(document.activeElement);
+
+      // gg — first page
+      if (e.key === "g" && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
+        const now = Date.now();
+        if (now - lastGRef.current <= 500) {
+          e.preventDefault();
+          pageViewerRef.current?.scrollToPage(0);
+          lastGRef.current = 0;
+        } else {
+          lastGRef.current = now;
+        }
+        return;
+      }
+
+      // G — last page
+      if (e.key === "G" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(pageCount - 1);
+        return;
+      }
+
+      // j — next page
+      if (e.key === "j" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(Math.min(activePage + 1, pageCount - 1));
+        return;
+      }
+
+      // k — previous page
+      if (e.key === "k" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(Math.max(activePage - 1, 0));
+        return;
+      }
+
+      // J (Shift+j) — expand selection down (sidebar only)
+      if (e.key === "J" && !e.metaKey && !e.ctrlKey) {
+        if (!sidebarFocused) return;
+        e.preventDefault();
+        const { selectionAnchor } = useAppStore.getState();
+        const anchor = selectionAnchor ?? activePage;
+        const cursor = Math.min(activePage + 1, pageCount - 1);
+        useAppStore.getState().setActivePage(cursor);
+        useAppStore.getState().selectPageRange(anchor, cursor);
+        return;
+      }
+
+      // K (Shift+k) — expand selection up (sidebar only)
+      if (e.key === "K" && !e.metaKey && !e.ctrlKey) {
+        if (!sidebarFocused) return;
+        e.preventDefault();
+        const { selectionAnchor } = useAppStore.getState();
+        const anchor = selectionAnchor ?? activePage;
+        const cursor = Math.max(activePage - 1, 0);
+        useAppStore.getState().setActivePage(cursor);
+        useAppStore.getState().selectPageRange(anchor, cursor);
+        return;
+      }
+
+      // PageDown — next page
+      if (e.key === "PageDown") {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(Math.min(activePage + 1, pageCount - 1));
+        return;
+      }
+
+      // PageUp — previous page
+      if (e.key === "PageUp") {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(Math.max(activePage - 1, 0));
+        return;
+      }
+
+      // Home — first page
+      if (e.key === "Home") {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(0);
+        return;
+      }
+
+      // End — last page
+      if (e.key === "End") {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(pageCount - 1);
+        return;
+      }
+
+      // Shift+ArrowDown — expand selection down (sidebar only)
+      if (e.key === "ArrowDown" && e.shiftKey && !e.metaKey && !e.ctrlKey) {
+        if (!sidebarFocused) return;
+        e.preventDefault();
+        const { selectionAnchor } = useAppStore.getState();
+        const anchor = selectionAnchor ?? activePage;
+        const cursor = Math.min(activePage + 1, pageCount - 1);
+        useAppStore.getState().setActivePage(cursor);
+        useAppStore.getState().selectPageRange(anchor, cursor);
+        return;
+      }
+
+      // Shift+ArrowUp — expand selection up (sidebar only)
+      if (e.key === "ArrowUp" && e.shiftKey && !e.metaKey && !e.ctrlKey) {
+        if (!sidebarFocused) return;
+        e.preventDefault();
+        const { selectionAnchor } = useAppStore.getState();
+        const anchor = selectionAnchor ?? activePage;
+        const cursor = Math.max(activePage - 1, 0);
+        useAppStore.getState().setActivePage(cursor);
+        useAppStore.getState().selectPageRange(anchor, cursor);
+        return;
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [pageViewerRef, sidebarRef]);
+}

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -25,6 +25,23 @@ describe("isDirty", () => {
     useAppStore.getState().setIsDirty(false);
     expect(useAppStore.getState().isDirty).toBe(false);
   });
+
+  it("setIsDirty(true) also marks the active tab's isDirty in the tabs array", () => {
+    useAppStore.setState({ tabs: [], activeDocId: null, docViewStates: new Map() });
+    useAppStore.getState().addTab(MANIFEST_A);
+    useAppStore.getState().setIsDirty(true);
+    const tab = useAppStore.getState().tabs.find((t) => t.docId === 1);
+    expect(tab?.isDirty).toBe(true);
+  });
+
+  it("setIsDirty(false) also clears the active tab's isDirty in the tabs array", () => {
+    useAppStore.setState({ tabs: [], activeDocId: null, docViewStates: new Map() });
+    useAppStore.getState().addTab(MANIFEST_A);
+    useAppStore.getState().setIsDirty(true);
+    useAppStore.getState().setIsDirty(false);
+    const tab = useAppStore.getState().tabs.find((t) => t.docId === 1);
+    expect(tab?.isDirty).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { useAppStore } from "@/store";
+import { useAppStore, DEFAULT_DOC_VIEW_STATE } from "@/store";
+import type { DocumentManifest } from "@/types";
 
 beforeEach(() => {
   useAppStore.setState({ isDirty: false, selectedPages: new Set() });
@@ -142,6 +143,235 @@ describe("recentFiles", () => {
     useAppStore.setState({ recentFiles: ["/a.pdf"] });
     useAppStore.getState().clearRecentFiles();
     expect(useAppStore.getState().recentFiles).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tab management
+// ---------------------------------------------------------------------------
+
+const MANIFEST_A: DocumentManifest = {
+  doc_id: 1,
+  filename: "a.pdf",
+  path: "/a.pdf",
+  page_count: 2,
+  page_sizes: [],
+  can_undo: false,
+  can_redo: false,
+};
+
+const MANIFEST_B: DocumentManifest = {
+  doc_id: 2,
+  filename: "b.pdf",
+  path: "/b.pdf",
+  page_count: 3,
+  page_sizes: [],
+  can_undo: false,
+  can_redo: false,
+};
+
+const MANIFEST_C: DocumentManifest = {
+  doc_id: 3,
+  filename: "c.pdf",
+  path: "/c.pdf",
+  page_count: 1,
+  page_sizes: [],
+  can_undo: false,
+  can_redo: false,
+};
+
+describe("tab management", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      tabs: [],
+      activeDocId: null,
+      docViewStates: new Map(),
+      activePage: 0,
+      zoom: 75,
+      zoomMode: "manual",
+      selectedPages: new Set(),
+      isDirty: false,
+    });
+  });
+
+  describe("addTab", () => {
+    it("sets activeDocId to the new doc", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      expect(useAppStore.getState().activeDocId).toBe(1);
+    });
+
+    it("appends a TabEntry to tabs", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      const { tabs } = useAppStore.getState();
+      expect(tabs).toHaveLength(1);
+      expect(tabs[0].docId).toBe(1);
+      expect(tabs[0].filename).toBe("a.pdf");
+      expect(tabs[0].pageCount).toBe(2);
+    });
+
+    it("initializes docViewState for the new doc", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      const state = useAppStore.getState().docViewStates.get(1);
+      expect(state).toBeDefined();
+      expect(state?.zoom).toBe(DEFAULT_DOC_VIEW_STATE.zoom);
+    });
+
+    it("resets top-level view state to defaults", () => {
+      useAppStore.setState({ zoom: 200, activePage: 5, isDirty: true });
+      useAppStore.getState().addTab(MANIFEST_A);
+      const s = useAppStore.getState();
+      expect(s.activePage).toBe(0);
+      expect(s.zoom).toBe(75);
+      expect(s.isDirty).toBe(false);
+    });
+
+    it("saves previous active doc's state before switching", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.setState({ zoom: 150, activePage: 3 });
+      useAppStore.getState().addTab(MANIFEST_B);
+      // A's state should have been saved
+      const aState = useAppStore.getState().docViewStates.get(1);
+      expect(aState?.zoom).toBe(150);
+      expect(aState?.activePage).toBe(3);
+    });
+
+    it("opening two tabs gives two entries", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      expect(useAppStore.getState().tabs).toHaveLength(2);
+      expect(useAppStore.getState().activeDocId).toBe(2);
+    });
+  });
+
+  describe("removeTab", () => {
+    it("removes the tab from tabs and docViewStates", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().removeTab(1);
+      expect(useAppStore.getState().tabs).toHaveLength(0);
+      expect(useAppStore.getState().docViewStates.has(1)).toBe(false);
+    });
+
+    it("sets activeDocId to null when last tab is closed", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().removeTab(1);
+      expect(useAppStore.getState().activeDocId).toBeNull();
+    });
+
+    it("switches to left neighbour when active tab is closed", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      // B is active; close B → should go to A
+      useAppStore.getState().removeTab(2);
+      expect(useAppStore.getState().activeDocId).toBe(1);
+      expect(useAppStore.getState().tabs).toHaveLength(1);
+    });
+
+    it("switches to first tab when leftmost active tab is closed with others present", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      useAppStore.getState().addTab(MANIFEST_C);
+      // manually make A active (leftmost)
+      useAppStore.getState().setActiveDocId(1);
+      useAppStore.getState().removeTab(1);
+      // Should fall through to B (now first)
+      expect(useAppStore.getState().activeDocId).toBe(2);
+    });
+
+    it("closing a non-active tab does not change activeDocId", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      // B is active; close A
+      useAppStore.getState().removeTab(1);
+      expect(useAppStore.getState().activeDocId).toBe(2);
+      expect(useAppStore.getState().tabs).toHaveLength(1);
+    });
+  });
+
+  describe("setActiveDocId", () => {
+    it("saves current top-level state to the outgoing doc", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      useAppStore.setState({ zoom: 200, activePage: 7 });
+      // Switch away from B
+      useAppStore.getState().setActiveDocId(1);
+      expect(useAppStore.getState().docViewStates.get(2)?.zoom).toBe(200);
+      expect(useAppStore.getState().docViewStates.get(2)?.activePage).toBe(7);
+    });
+
+    it("restores the target doc's saved state into top-level fields", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      // After both tabs are open, override A's saved state
+      useAppStore.setState({
+        docViewStates: new Map([
+          [1, { ...DEFAULT_DOC_VIEW_STATE, zoom: 150, activePage: 4 }],
+          [2, { ...DEFAULT_DOC_VIEW_STATE }],
+        ]),
+      });
+      useAppStore.getState().setActiveDocId(1);
+      expect(useAppStore.getState().zoom).toBe(150);
+      expect(useAppStore.getState().activePage).toBe(4);
+    });
+
+    it("updates activeDocId", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      useAppStore.getState().setActiveDocId(1);
+      expect(useAppStore.getState().activeDocId).toBe(1);
+    });
+  });
+
+  describe("reorderTabs", () => {
+    it("moves a tab from one index to another", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      useAppStore.getState().addTab(MANIFEST_C);
+      useAppStore.getState().reorderTabs(0, 2);
+      const ids = useAppStore.getState().tabs.map((t) => t.docId);
+      expect(ids).toEqual([2, 3, 1]);
+    });
+
+    it("moves a tab from last to first", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      useAppStore.getState().addTab(MANIFEST_C);
+      useAppStore.getState().reorderTabs(2, 0);
+      const ids = useAppStore.getState().tabs.map((t) => t.docId);
+      expect(ids).toEqual([3, 1, 2]);
+    });
+
+    it("does not change activeDocId", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      useAppStore.getState().reorderTabs(0, 1);
+      expect(useAppStore.getState().activeDocId).toBe(2);
+    });
+
+    it("is a no-op when fromIndex === toIndex", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      useAppStore.getState().reorderTabs(1, 1);
+      const ids = useAppStore.getState().tabs.map((t) => t.docId);
+      expect(ids).toEqual([1, 2]);
+    });
+  });
+
+  describe("per-doc state isolation", () => {
+    it("setZoom on active doc does not affect inactive doc's saved state", () => {
+      useAppStore.getState().addTab(MANIFEST_A);
+      useAppStore.getState().addTab(MANIFEST_B);
+      // Save A's state at zoom=100
+      useAppStore.setState({
+        docViewStates: new Map([
+          [1, { ...DEFAULT_DOC_VIEW_STATE, zoom: 100 }],
+          [2, { ...DEFAULT_DOC_VIEW_STATE, zoom: 75 }],
+        ]),
+      });
+      // Change active (B) zoom
+      useAppStore.getState().setZoom(300);
+      // A's saved state unchanged
+      expect(useAppStore.getState().docViewStates.get(1)?.zoom).toBe(100);
+    });
   });
 });
 

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -427,3 +427,59 @@ describe("infoPanelOpen", () => {
     expect(useAppStore.getState().infoPanelOpen).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// selectionAnchor
+// ---------------------------------------------------------------------------
+
+describe("selectionAnchor", () => {
+  beforeEach(() => {
+    useAppStore.setState({ selectionAnchor: null, selectedPages: new Set() });
+  });
+
+  it("starts null", () => {
+    expect(useAppStore.getState().selectionAnchor).toBeNull();
+  });
+
+  it("setSelectionAnchor(3) sets anchor to 3", () => {
+    useAppStore.getState().setSelectionAnchor(3);
+    expect(useAppStore.getState().selectionAnchor).toBe(3);
+  });
+
+  it("setSelectionAnchor(null) clears the anchor", () => {
+    useAppStore.setState({ selectionAnchor: 5 });
+    useAppStore.getState().setSelectionAnchor(null);
+    expect(useAppStore.getState().selectionAnchor).toBeNull();
+  });
+
+  it("clearSelection() also resets selectionAnchor to null", () => {
+    useAppStore.setState({ selectionAnchor: 2, selectedPages: new Set([1, 2, 3]) });
+    useAppStore.getState().clearSelection();
+    expect(useAppStore.getState().selectedPages.size).toBe(0);
+    expect(useAppStore.getState().selectionAnchor).toBeNull();
+  });
+
+  it("selectionAnchor is saved and restored on tab switch", () => {
+    useAppStore.setState({
+      tabs: [],
+      activeDocId: null,
+      docViewStates: new Map(),
+      activePage: 0,
+      zoom: 75,
+      zoomMode: "manual",
+      selectedPages: new Set(),
+      isDirty: false,
+      selectionAnchor: null,
+    });
+    useAppStore.getState().addTab(MANIFEST_A);
+    useAppStore.getState().setSelectionAnchor(4);
+
+    useAppStore.getState().addTab(MANIFEST_B);
+    // anchor should reset for new doc
+    expect(useAppStore.getState().selectionAnchor).toBeNull();
+
+    // switch back to A
+    useAppStore.getState().setActiveDocId(1);
+    expect(useAppStore.getState().selectionAnchor).toBe(4);
+  });
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -190,7 +190,16 @@ export const useAppStore = create<AppStore>()(
       zoomMode: "manual",
       setZoomMode: (zoomMode) => set({ zoomMode }),
       isDirty: false,
-      setIsDirty: (dirty) => set({ isDirty: dirty }),
+      setIsDirty: (dirty) =>
+        set((s) => ({
+          isDirty: dirty,
+          tabs:
+            s.activeDocId !== null
+              ? s.tabs.map((t) =>
+                  t.docId === s.activeDocId ? { ...t, isDirty: dirty } : t
+                )
+              : s.tabs,
+        })),
       selectedPages: new Set<number>(),
       togglePageSelection: (index) =>
         set((s) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -13,6 +13,7 @@ export interface DocViewState {
   zoomMode: ZoomMode;
   selectedPages: ReadonlySet<number>;
   isDirty: boolean;
+  selectionAnchor: number | null;
 }
 
 export const DEFAULT_DOC_VIEW_STATE: DocViewState = {
@@ -21,6 +22,7 @@ export const DEFAULT_DOC_VIEW_STATE: DocViewState = {
   zoomMode: "manual",
   selectedPages: new Set(),
   isDirty: false,
+  selectionAnchor: null,
 };
 
 export interface TabEntry {
@@ -58,6 +60,8 @@ interface AppStore {
   selectPageRange(from: number, to: number): void;
   clearSelection(): void;
   selectAll(count: number): void;
+  selectionAnchor: number | null;
+  setSelectionAnchor: (i: number | null) => void;
 
   // Persistent preferences
   sidebarWidth: number;
@@ -84,6 +88,7 @@ function captureViewState(s: AppStore): DocViewState {
     zoomMode: s.zoomMode,
     selectedPages: s.selectedPages,
     isDirty: s.isDirty,
+    selectionAnchor: s.selectionAnchor,
   };
 }
 
@@ -215,12 +220,14 @@ export const useAppStore = create<AppStore>()(
         for (let i = lo; i <= hi; i++) next.add(i);
         set({ selectedPages: next });
       },
-      clearSelection: () => set({ selectedPages: new Set<number>() }),
+      clearSelection: () => set({ selectedPages: new Set<number>(), selectionAnchor: null }),
       selectAll: (count) => {
         const next = new Set<number>();
         for (let i = 0; i < count; i++) next.add(i);
         set({ selectedPages: next });
       },
+      selectionAnchor: null,
+      setSelectionAnchor: (i) => set({ selectionAnchor: i }),
 
       // Persistent preferences
       sidebarWidth: 160,

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,26 +1,56 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import type { DocumentManifest, PageSize } from "@/types";
 
+export type { PageSize };
 export type Theme = "light" | "dark" | "system";
 export type ZoomMode = "fit-width" | "manual";
 export type PageDisplay = "continuous" | "single" | "spread";
 
+export interface DocViewState {
+  activePage: number;
+  zoom: number;
+  zoomMode: ZoomMode;
+  selectedPages: ReadonlySet<number>;
+  isDirty: boolean;
+}
+
+export const DEFAULT_DOC_VIEW_STATE: DocViewState = {
+  activePage: 0,
+  zoom: 75,
+  zoomMode: "manual",
+  selectedPages: new Set(),
+  isDirty: false,
+};
+
+export interface TabEntry {
+  docId: number;
+  filename: string;
+  path: string;
+  pageCount: number;
+  pageSizes: PageSize[];
+  canUndo: boolean;
+  canRedo: boolean;
+  isDirty: boolean;
+}
+
 interface AppStore {
+  // Tab management
+  tabs: TabEntry[];
+  activeDocId: number | null;
+  docViewStates: Map<number, DocViewState>;
+  addTab(manifest: DocumentManifest): void;
+  removeTab(docId: number): void;
+  setActiveDocId(docId: number): void;
+  reorderTabs(fromIndex: number, toIndex: number): void;
+
+  // Active doc view state (top-level live copy; saved/restored on tab switch)
   activePage: number;
   setActivePage(index: number): void;
-  sidebarWidth: number;
-  setSidebarWidth(width: number): void;
-  theme: Theme;
-  setTheme(theme: Theme): void;
-  recentFiles: string[];
-  addRecentFile(path: string): void;
-  clearRecentFiles(): void;
   zoom: number;
   setZoom(zoom: number): void;
   zoomMode: ZoomMode;
   setZoomMode(mode: ZoomMode): void;
-  pageDisplay: PageDisplay;
-  setPageDisplay(mode: PageDisplay): void;
   isDirty: boolean;
   setIsDirty(dirty: boolean): void;
   selectedPages: ReadonlySet<number>;
@@ -28,6 +58,17 @@ interface AppStore {
   selectPageRange(from: number, to: number): void;
   clearSelection(): void;
   selectAll(count: number): void;
+
+  // Persistent preferences
+  sidebarWidth: number;
+  setSidebarWidth(width: number): void;
+  theme: Theme;
+  setTheme(theme: Theme): void;
+  recentFiles: string[];
+  addRecentFile(path: string): void;
+  clearRecentFiles(): void;
+  pageDisplay: PageDisplay;
+  setPageDisplay(mode: PageDisplay): void;
   infoPanelOpen: boolean;
   setInfoPanelOpen(open: boolean): void;
   toggleInfoPanel(): void;
@@ -35,28 +76,119 @@ interface AppStore {
 
 export const ZOOM_STEPS = [25, 50, 75, 100, 125, 150, 200, 300, 400];
 
+/** Snapshot the current top-level view state fields into a DocViewState object. */
+function captureViewState(s: AppStore): DocViewState {
+  return {
+    activePage: s.activePage,
+    zoom: s.zoom,
+    zoomMode: s.zoomMode,
+    selectedPages: s.selectedPages,
+    isDirty: s.isDirty,
+  };
+}
+
 export const useAppStore = create<AppStore>()(
   persist(
-    (set) => ({
+    (set, get) => ({
+      // Tab management
+      tabs: [],
+      activeDocId: null,
+      docViewStates: new Map(),
+
+      addTab: (manifest) =>
+        set((s) => {
+          const saved = new Map(s.docViewStates);
+          // Save current active doc's state before switching
+          if (s.activeDocId !== null) {
+            saved.set(s.activeDocId, captureViewState(s));
+          }
+          // Initialize new doc's state
+          saved.set(manifest.doc_id, { ...DEFAULT_DOC_VIEW_STATE });
+          const newTab: TabEntry = {
+            docId: manifest.doc_id,
+            filename: manifest.filename,
+            path: manifest.path,
+            pageCount: manifest.page_count,
+            pageSizes: manifest.page_sizes,
+            canUndo: manifest.can_undo,
+            canRedo: manifest.can_redo,
+            isDirty: false,
+          };
+          return {
+            tabs: [...s.tabs, newTab],
+            activeDocId: manifest.doc_id,
+            docViewStates: saved,
+            // Reset top-level live state for the new doc
+            ...DEFAULT_DOC_VIEW_STATE,
+          };
+        }),
+
+      removeTab: (docId) =>
+        set((s) => {
+          const idx = s.tabs.findIndex((t) => t.docId === docId);
+          if (idx === -1) return {};
+          const nextTabs = s.tabs.filter((t) => t.docId !== docId);
+          const nextStates = new Map(s.docViewStates);
+          nextStates.delete(docId);
+
+          // Determine next active doc
+          let nextActiveId: number | null = s.activeDocId;
+          let liveOverride: Partial<DocViewState> = {};
+
+          if (s.activeDocId === docId) {
+            if (nextTabs.length === 0) {
+              nextActiveId = null;
+              liveOverride = { ...DEFAULT_DOC_VIEW_STATE };
+            } else {
+              // Pick left neighbour, falling back to the new first tab
+              const neighbourIdx = Math.max(0, idx - 1);
+              nextActiveId = nextTabs[neighbourIdx].docId;
+              const saved = nextStates.get(nextActiveId);
+              liveOverride = saved ? { ...saved } : { ...DEFAULT_DOC_VIEW_STATE };
+            }
+          }
+
+          return {
+            tabs: nextTabs,
+            activeDocId: nextActiveId,
+            docViewStates: nextStates,
+            ...liveOverride,
+          };
+        }),
+
+      reorderTabs: (fromIndex, toIndex) =>
+        set((s) => {
+          if (fromIndex === toIndex) return {};
+          const next = [...s.tabs];
+          const [moved] = next.splice(fromIndex, 1);
+          next.splice(toIndex, 0, moved);
+          return { tabs: next };
+        }),
+
+      setActiveDocId: (docId) =>
+        set((s) => {
+          if (s.activeDocId === docId) return {};
+          // Save current doc state
+          const saved = new Map(s.docViewStates);
+          if (s.activeDocId !== null) {
+            saved.set(s.activeDocId, captureViewState(s));
+          }
+          // Restore target doc state
+          const target = saved.get(docId) ?? DEFAULT_DOC_VIEW_STATE;
+          return {
+            activeDocId: docId,
+            docViewStates: saved,
+            ...target,
+          };
+        }),
+
+      // Active doc view state
       activePage: 0,
       setActivePage: (index) => set({ activePage: index }),
-      sidebarWidth: 160,
-      setSidebarWidth: (width) => set({ sidebarWidth: width }),
-      theme: "system",
-      setTheme: (theme) => set({ theme }),
-      recentFiles: [],
-      addRecentFile: (path) =>
-        set((s) => {
-          const without = s.recentFiles.filter((p) => p !== path);
-          return { recentFiles: [path, ...without].slice(0, 10) };
-        }),
-      clearRecentFiles: () => set({ recentFiles: [] }),
       zoom: 75,
       setZoom: (zoom) => set({ zoom }),
       zoomMode: "manual",
       setZoomMode: (zoomMode) => set({ zoomMode }),
-      pageDisplay: "continuous",
-      setPageDisplay: (pageDisplay) => set({ pageDisplay }),
       isDirty: false,
       setIsDirty: (dirty) => set({ isDirty: dirty }),
       selectedPages: new Set<number>(),
@@ -80,13 +212,28 @@ export const useAppStore = create<AppStore>()(
         for (let i = 0; i < count; i++) next.add(i);
         set({ selectedPages: next });
       },
+
+      // Persistent preferences
+      sidebarWidth: 160,
+      setSidebarWidth: (width) => set({ sidebarWidth: width }),
+      theme: "system",
+      setTheme: (theme) => set({ theme }),
+      recentFiles: [],
+      addRecentFile: (path) =>
+        set((s) => {
+          const without = s.recentFiles.filter((p) => p !== path);
+          return { recentFiles: [path, ...without].slice(0, 10) };
+        }),
+      clearRecentFiles: () => set({ recentFiles: [] }),
+      pageDisplay: "continuous",
+      setPageDisplay: (pageDisplay) => set({ pageDisplay }),
       infoPanelOpen: false,
       setInfoPanelOpen: (open) => set({ infoPanelOpen: open }),
       toggleInfoPanel: () => set((s) => ({ infoPanelOpen: !s.infoPanelOpen })),
     }),
     {
       name: "collate-settings",
-      // Only persist user preferences, not transient document state
+      // Only persist user preferences, not transient document/tab state
       partialize: (state) => ({ theme: state.theme, recentFiles: state.recentFiles }),
     }
   )

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,14 @@
+export interface PageSize {
+  width_pts: number;
+  height_pts: number;
+}
+
+export interface DocumentManifest {
+  doc_id: number;
+  page_count: number;
+  filename: string;
+  path: string;
+  page_sizes: PageSize[];
+  can_undo: boolean;
+  can_redo: boolean;
+}


### PR DESCRIPTION
## Summary
- Adds `useKeyboardNav` hook — single `window` keydown listener for all keyboard navigation
- Vim-style page navigation: `j`/`k` (next/prev), `gg`/`G` (first/last), with `PgDn`/`PgUp`/`Home`/`End` fallbacks
- Sidebar selection expansion via `Shift+↓`/`Shift+↑` and `Shift+j`/`Shift+k` (sidebar-focused only)
- `selectionAnchor` added to `DocViewState` (persists across tab switches)
- Shortcut overlay updated: new "Page Navigation" section with two-column Standard/Vim layout, "Navigation" renamed to "Tabs", selection section gains expand rows

## Test Plan
- [ ] Open a PDF, click the viewer, press `j`/`k` — pages advance/retreat
- [ ] Press `PgDn`/`PgUp` — same behaviour
- [ ] Press `gg` (two g's within 500ms) — jumps to page 1; single `g` does nothing
- [ ] Press `G` / `End` — jumps to last page
- [ ] Click a text input, press `j` — no navigation fires
- [ ] Click a sidebar thumbnail to focus sidebar, `Shift+↓` — selection expands; `Shift+↑` contracts/expands
- [ ] Switch tabs while sidebar selection is active — anchor survives, expansion continues on return
- [ ] Press `?` — overlay shows Page Navigation section with correct two-column layout, Tabs section label

Closes #7