### PR TITLE
feat: keyboard nav — sidebar focus, anchor fix, Escape to clear

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ lib/
 
 # Claude Code local settings (personal overrides, not for team)
 .claude/settings.local.json
+.superpowers/
 
 # Editor directories and files
 .vscode/*

--- a/docs/superpowers/plans/2026-04-18-keyboard-navigation.md
+++ b/docs/superpowers/plans/2026-04-18-keyboard-navigation.md
@@ -1,0 +1,1069 @@
+# Keyboard Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire Vim-style page navigation (j/k/gg/G) and standard fallbacks (PgUp/PgDn/Home/End) via a single `useKeyboardNav` hook, add sidebar selection expansion (Shift+j/k/↑/↓), and update the shortcut overlay.
+
+**Architecture:** All keyboard handling lives in `src/hooks/useKeyboardNav.ts` — one place to look, called once from `App.tsx`. The hook reads store state via `useAppStore.getState()` and fires `pageViewerRef.current?.scrollToPage()`. A `selectionAnchor` field added to the zustand store (and `DocViewState`) lets selection expansion survive tab switches.
+
+**Tech Stack:** React + TypeScript, Zustand, Vitest + Testing Library, shadcn/ui Dialog, Tailwind CSS.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/store.ts` | Modify | Add `selectionAnchor` to `AppStore`, `DocViewState`, `captureViewState`, `clearSelection` |
+| `src/store.test.ts` | Modify | Add tests for `selectionAnchor` behaviour |
+| `src/hooks/useKeyboardNav.ts` | **Create** | All keyboard nav logic |
+| `src/hooks/useKeyboardNav.test.ts` | **Create** | Unit tests for the hook |
+| `src/App.tsx` | Modify | Call `useKeyboardNav`, create `sidebarRef`, pass to `PageSidebar` |
+| `src/components/PageSidebar.tsx` | Modify | Accept `containerRef` prop; replace local `anchorRef` with store `selectionAnchor` |
+| `src/components/ShortcutOverlay.tsx` | Modify | Add Page Navigation section, rename Navigation→Tabs, add two-column layout for dual-binding sections |
+
+---
+
+## Task 1 — Store: add `selectionAnchor`
+
+**Files:**
+- Modify: `src/store.ts`
+- Modify: `src/store.test.ts`
+
+### Step 1.1 — Write failing tests
+
+Add to the bottom of `src/store.test.ts`:
+
+```typescript
+// ---------------------------------------------------------------------------
+// selectionAnchor
+// ---------------------------------------------------------------------------
+
+describe("selectionAnchor", () => {
+  beforeEach(() => {
+    useAppStore.setState({ selectionAnchor: null, selectedPages: new Set() });
+  });
+
+  it("starts null", () => {
+    expect(useAppStore.getState().selectionAnchor).toBeNull();
+  });
+
+  it("setSelectionAnchor(3) sets anchor to 3", () => {
+    useAppStore.getState().setSelectionAnchor(3);
+    expect(useAppStore.getState().selectionAnchor).toBe(3);
+  });
+
+  it("setSelectionAnchor(null) clears the anchor", () => {
+    useAppStore.setState({ selectionAnchor: 5 });
+    useAppStore.getState().setSelectionAnchor(null);
+    expect(useAppStore.getState().selectionAnchor).toBeNull();
+  });
+
+  it("clearSelection() also resets selectionAnchor to null", () => {
+    useAppStore.setState({ selectionAnchor: 2, selectedPages: new Set([1, 2, 3]) });
+    useAppStore.getState().clearSelection();
+    expect(useAppStore.getState().selectedPages.size).toBe(0);
+    expect(useAppStore.getState().selectionAnchor).toBeNull();
+  });
+
+  it("selectionAnchor is saved and restored on tab switch", () => {
+    useAppStore.setState({
+      tabs: [],
+      activeDocId: null,
+      docViewStates: new Map(),
+      activePage: 0,
+      zoom: 75,
+      zoomMode: "manual",
+      selectedPages: new Set(),
+      isDirty: false,
+      selectionAnchor: null,
+    });
+    useAppStore.getState().addTab(MANIFEST_A);
+    useAppStore.getState().setSelectionAnchor(4);
+
+    useAppStore.getState().addTab(MANIFEST_B);
+    // anchor should reset for new doc
+    expect(useAppStore.getState().selectionAnchor).toBeNull();
+
+    // switch back to A
+    useAppStore.getState().setActiveDocId(1);
+    expect(useAppStore.getState().selectionAnchor).toBe(4);
+  });
+});
+```
+
+- [ ] **Step 1.2 — Run tests and confirm they fail**
+
+```bash
+pnpm exec vitest run src/store.test.ts
+```
+
+Expected: 5 failures mentioning `selectionAnchor` not found.
+
+- [ ] **Step 1.3 — Update `DocViewState` interface and `DEFAULT_DOC_VIEW_STATE`**
+
+In `src/store.ts`, update the `DocViewState` interface:
+
+```typescript
+export interface DocViewState {
+  activePage: number;
+  zoom: number;
+  zoomMode: ZoomMode;
+  selectedPages: ReadonlySet<number>;
+  isDirty: boolean;
+  selectionAnchor: number | null;
+}
+```
+
+Update `DEFAULT_DOC_VIEW_STATE`:
+
+```typescript
+export const DEFAULT_DOC_VIEW_STATE: DocViewState = {
+  activePage: 0,
+  zoom: 75,
+  zoomMode: "manual",
+  selectedPages: new Set(),
+  isDirty: false,
+  selectionAnchor: null,
+};
+```
+
+- [ ] **Step 1.4 — Update `captureViewState`**
+
+```typescript
+function captureViewState(s: AppStore): DocViewState {
+  return {
+    activePage: s.activePage,
+    zoom: s.zoom,
+    zoomMode: s.zoomMode,
+    selectedPages: s.selectedPages,
+    isDirty: s.isDirty,
+    selectionAnchor: s.selectionAnchor,
+  };
+}
+```
+
+- [ ] **Step 1.5 — Add `selectionAnchor` to `AppStore` interface**
+
+In the `AppStore` interface, add after the `clearSelection` and `selectAll` lines:
+
+```typescript
+selectionAnchor: number | null;
+setSelectionAnchor: (i: number | null) => void;
+```
+
+- [ ] **Step 1.6 — Implement in the store body**
+
+Replace the existing `clearSelection` line:
+
+```typescript
+clearSelection: () => set({ selectedPages: new Set<number>() }),
+```
+
+with:
+
+```typescript
+clearSelection: () => set({ selectedPages: new Set<number>(), selectionAnchor: null }),
+```
+
+Add after `clearSelection` and before `selectAll`:
+
+```typescript
+selectionAnchor: null,
+setSelectionAnchor: (i) => set({ selectionAnchor: i }),
+```
+
+- [ ] **Step 1.7 — Run tests and confirm they pass**
+
+```bash
+pnpm exec vitest run src/store.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 1.8 — Commit**
+
+```bash
+git add src/store.ts src/store.test.ts
+git commit -m "feat: add selectionAnchor to store and DocViewState"
+```
+
+---
+
+## Task 2 — `useKeyboardNav` hook
+
+**Files:**
+- Create: `src/hooks/useKeyboardNav.test.ts`
+- Create: `src/hooks/useKeyboardNav.ts`
+
+### Step 2.1 — Write the test file
+
+Create `src/hooks/useKeyboardNav.test.ts`:
+
+```typescript
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useKeyboardNav } from "./useKeyboardNav";
+import { useAppStore } from "@/store";
+import type { DocumentManifest } from "@/types";
+
+// Minimal tab fixture
+const MANIFEST: DocumentManifest = {
+  doc_id: 1,
+  filename: "test.pdf",
+  path: "/test.pdf",
+  page_count: 10,
+  page_sizes: [],
+  can_undo: false,
+  can_redo: false,
+};
+
+function fireKey(key: string, extra: Partial<KeyboardEventInit> = {}) {
+  window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...extra }));
+}
+
+function makeRefs(sidebarEl?: HTMLElement | null) {
+  const scrollToPage = vi.fn();
+  const pageViewerRef = { current: { scrollToPage } } as any;
+  const sidebarRef = { current: sidebarEl ?? null } as any;
+  return { scrollToPage, pageViewerRef, sidebarRef };
+}
+
+beforeEach(() => {
+  useAppStore.setState({
+    tabs: [],
+    activeDocId: null,
+    docViewStates: new Map(),
+    activePage: 0,
+    zoom: 75,
+    zoomMode: "manual",
+    selectedPages: new Set(),
+    isDirty: false,
+    selectionAnchor: null,
+  });
+  useAppStore.getState().addTab(MANIFEST);
+  useAppStore.setState({ activePage: 5 }); // start mid-document
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("page navigation — no document open", () => {
+  it("does not call scrollToPage when activeDocId is null", () => {
+    useAppStore.setState({ activeDocId: null });
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("j");
+    expect(scrollToPage).not.toHaveBeenCalled();
+  });
+});
+
+describe("page navigation — input guard", () => {
+  it("does not fire when target is an <input>", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "j", bubbles: true, target: input } as any)
+    );
+    // Use Object.defineProperty trick since KeyboardEvent target is read-only
+    const event = new KeyboardEvent("keydown", { key: "j", bubbles: true });
+    Object.defineProperty(event, "target", { value: input });
+    window.dispatchEvent(event);
+    expect(scrollToPage).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+  });
+});
+
+describe("j / PageDown — next page", () => {
+  it("j scrolls to activePage + 1", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("j");
+    expect(scrollToPage).toHaveBeenCalledWith(6);
+  });
+
+  it("PageDown scrolls to activePage + 1", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("PageDown");
+    expect(scrollToPage).toHaveBeenCalledWith(6);
+  });
+
+  it("j clamps at last page", () => {
+    useAppStore.setState({ activePage: 9 }); // last page (pageCount=10)
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("j");
+    expect(scrollToPage).toHaveBeenCalledWith(9);
+  });
+});
+
+describe("k / PageUp — previous page", () => {
+  it("k scrolls to activePage - 1", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("k");
+    expect(scrollToPage).toHaveBeenCalledWith(4);
+  });
+
+  it("PageUp scrolls to activePage - 1", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("PageUp");
+    expect(scrollToPage).toHaveBeenCalledWith(4);
+  });
+
+  it("k clamps at first page", () => {
+    useAppStore.setState({ activePage: 0 });
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("k");
+    expect(scrollToPage).toHaveBeenCalledWith(0);
+  });
+});
+
+describe("G / End — last page", () => {
+  it("G jumps to last page", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("G");
+    expect(scrollToPage).toHaveBeenCalledWith(9);
+  });
+
+  it("End jumps to last page", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("End");
+    expect(scrollToPage).toHaveBeenCalledWith(9);
+  });
+});
+
+describe("Home — first page", () => {
+  it("Home jumps to first page", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("Home");
+    expect(scrollToPage).toHaveBeenCalledWith(0);
+  });
+});
+
+describe("gg — first page", () => {
+  it("two g presses within 500ms jump to first page", () => {
+    vi.useFakeTimers();
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("g");
+    vi.advanceTimersByTime(400);
+    fireKey("g");
+    expect(scrollToPage).toHaveBeenCalledWith(0);
+  });
+
+  it("two g presses more than 500ms apart do not jump", () => {
+    vi.useFakeTimers();
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("g");
+    vi.advanceTimersByTime(501);
+    fireKey("g");
+    expect(scrollToPage).not.toHaveBeenCalled();
+  });
+
+  it("single g press does not jump", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("g");
+    expect(scrollToPage).not.toHaveBeenCalled();
+  });
+});
+
+describe("selection expansion — sidebar guard", () => {
+  function makeSidebarSetup() {
+    const sidebarEl = document.createElement("div");
+    document.body.appendChild(sidebarEl);
+    const child = document.createElement("button");
+    child.setAttribute("tabindex", "0");
+    sidebarEl.appendChild(child);
+    child.focus();
+    return { sidebarEl, cleanup: () => document.body.removeChild(sidebarEl) };
+  }
+
+  it("J (Shift+j) does not fire when sidebar not focused", () => {
+    const { pageViewerRef, sidebarRef } = makeRefs(null);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ selectionAnchor: 5 });
+    fireKey("J");
+    expect(useAppStore.getState().selectedPages.size).toBe(0);
+  });
+
+  it("J (Shift+j) expands selection down when sidebar focused", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 5, selectionAnchor: 5 });
+    fireKey("J");
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([5, 6]);
+    expect(useAppStore.getState().activePage).toBe(6);
+    cleanup();
+  });
+
+  it("K (Shift+k) expands selection up when sidebar focused", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 5, selectionAnchor: 5 });
+    fireKey("K");
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([4, 5]);
+    expect(useAppStore.getState().activePage).toBe(4);
+    cleanup();
+  });
+
+  it("Shift+ArrowDown expands selection down when sidebar focused", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 5, selectionAnchor: 5 });
+    fireKey("ArrowDown", { shiftKey: true });
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([5, 6]);
+    cleanup();
+  });
+
+  it("Shift+ArrowUp expands selection up when sidebar focused", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 5, selectionAnchor: 5 });
+    fireKey("ArrowUp", { shiftKey: true });
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([4, 5]);
+    cleanup();
+  });
+
+  it("selection expansion uses activePage as fallback anchor when selectionAnchor is null", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 3, selectionAnchor: null });
+    fireKey("J");
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([3, 4]);
+    cleanup();
+  });
+});
+```
+
+- [ ] **Step 2.2 — Run tests and confirm they fail**
+
+```bash
+pnpm exec vitest run src/hooks/useKeyboardNav.test.ts
+```
+
+Expected: module `useKeyboardNav` not found.
+
+- [ ] **Step 2.3 — Create `src/hooks/useKeyboardNav.ts`**
+
+```typescript
+import { useEffect, useRef } from "react";
+import type { RefObject } from "react";
+import { useAppStore } from "@/store";
+import type { PageViewerHandle } from "@/components/PageViewer";
+
+interface Options {
+  pageViewerRef: RefObject<PageViewerHandle | null>;
+  sidebarRef: RefObject<HTMLElement | null>;
+}
+
+function isInputFocused(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    target.contentEditable === "true"
+  );
+}
+
+export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
+  const lastGRef = useRef<number>(0);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (isInputFocused(e.target)) return;
+
+      const state = useAppStore.getState();
+      if (state.activeDocId === null) return;
+
+      const tab = state.tabs.find((t) => t.docId === state.activeDocId);
+      if (!tab || tab.pageCount === 0) return;
+
+      const { activePage } = state;
+      const pageCount = tab.pageCount;
+      const sidebarFocused =
+        sidebarRef.current != null &&
+        sidebarRef.current.contains(document.activeElement);
+
+      // gg — first page
+      if (e.key === "g" && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
+        const now = Date.now();
+        if (now - lastGRef.current <= 500) {
+          e.preventDefault();
+          pageViewerRef.current?.scrollToPage(0);
+          lastGRef.current = 0;
+        } else {
+          lastGRef.current = now;
+        }
+        return;
+      }
+
+      // G — last page
+      if (e.key === "G" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(pageCount - 1);
+        return;
+      }
+
+      // j — next page
+      if (e.key === "j" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(Math.min(activePage + 1, pageCount - 1));
+        return;
+      }
+
+      // k — previous page
+      if (e.key === "k" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(Math.max(activePage - 1, 0));
+        return;
+      }
+
+      // J (Shift+j) — expand selection down (sidebar only)
+      if (e.key === "J" && !e.metaKey && !e.ctrlKey) {
+        if (!sidebarFocused) return;
+        e.preventDefault();
+        const { selectionAnchor } = useAppStore.getState();
+        const anchor = selectionAnchor ?? activePage;
+        const cursor = Math.min(activePage + 1, pageCount - 1);
+        useAppStore.getState().setActivePage(cursor);
+        useAppStore.getState().selectPageRange(anchor, cursor);
+        return;
+      }
+
+      // K (Shift+k) — expand selection up (sidebar only)
+      if (e.key === "K" && !e.metaKey && !e.ctrlKey) {
+        if (!sidebarFocused) return;
+        e.preventDefault();
+        const { selectionAnchor } = useAppStore.getState();
+        const anchor = selectionAnchor ?? activePage;
+        const cursor = Math.max(activePage - 1, 0);
+        useAppStore.getState().setActivePage(cursor);
+        useAppStore.getState().selectPageRange(anchor, cursor);
+        return;
+      }
+
+      // PageDown — next page
+      if (e.key === "PageDown") {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(Math.min(activePage + 1, pageCount - 1));
+        return;
+      }
+
+      // PageUp — previous page
+      if (e.key === "PageUp") {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(Math.max(activePage - 1, 0));
+        return;
+      }
+
+      // Home — first page
+      if (e.key === "Home") {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(0);
+        return;
+      }
+
+      // End — last page
+      if (e.key === "End") {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(pageCount - 1);
+        return;
+      }
+
+      // Shift+ArrowDown — expand selection down (sidebar only)
+      if (e.key === "ArrowDown" && e.shiftKey && !e.metaKey && !e.ctrlKey) {
+        if (!sidebarFocused) return;
+        e.preventDefault();
+        const { selectionAnchor } = useAppStore.getState();
+        const anchor = selectionAnchor ?? activePage;
+        const cursor = Math.min(activePage + 1, pageCount - 1);
+        useAppStore.getState().setActivePage(cursor);
+        useAppStore.getState().selectPageRange(anchor, cursor);
+        return;
+      }
+
+      // Shift+ArrowUp — expand selection up (sidebar only)
+      if (e.key === "ArrowUp" && e.shiftKey && !e.metaKey && !e.ctrlKey) {
+        if (!sidebarFocused) return;
+        e.preventDefault();
+        const { selectionAnchor } = useAppStore.getState();
+        const anchor = selectionAnchor ?? activePage;
+        const cursor = Math.max(activePage - 1, 0);
+        useAppStore.getState().setActivePage(cursor);
+        useAppStore.getState().selectPageRange(anchor, cursor);
+        return;
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [pageViewerRef, sidebarRef]);
+}
+```
+
+- [ ] **Step 2.4 — Run tests and confirm they pass**
+
+```bash
+pnpm exec vitest run src/hooks/useKeyboardNav.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2.5 — Run full test suite to confirm no regressions**
+
+```bash
+make test-frontend
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2.6 — Commit**
+
+```bash
+git add src/hooks/useKeyboardNav.ts src/hooks/useKeyboardNav.test.ts
+git commit -m "feat: useKeyboardNav hook with Vim-style page navigation"
+```
+
+---
+
+## Task 3 — Wire hook and `sidebarRef` in `App.tsx`
+
+**Files:**
+- Modify: `src/App.tsx`
+
+- [ ] **Step 3.1 — Add `sidebarRef` and `useKeyboardNav` import**
+
+Add to the imports at the top of `src/App.tsx`:
+
+```typescript
+import { useKeyboardNav } from "@/hooks/useKeyboardNav";
+```
+
+- [ ] **Step 3.2 — Add `sidebarRef` declaration**
+
+In the `App` function, after the existing `viewerRef` declaration:
+
+```typescript
+const viewerRef = useRef<PageViewerHandle>(null);
+// Stable ref for use inside event listener closures
+const activeTabRef = useRef<TabEntry | null>(null);
+```
+
+Add:
+
+```typescript
+const sidebarRef = useRef<HTMLDivElement>(null);
+```
+
+- [ ] **Step 3.3 — Call the hook**
+
+After the `useTheme()` call, add:
+
+```typescript
+useKeyboardNav({ pageViewerRef: viewerRef, sidebarRef });
+```
+
+- [ ] **Step 3.4 — Pass `containerRef` to `PageSidebar`**
+
+Find the `PageSidebar` usage in the JSX:
+
+```tsx
+<PageSidebar
+  docId={activeTab.docId}
+  pageSizes={activeTab.pageSizes}
+  onScrollToPage={(i) => viewerRef.current?.scrollToPage(i)}
+  onBugReport={openBugReportForError}
+/>
+```
+
+Replace with:
+
+```tsx
+<PageSidebar
+  docId={activeTab.docId}
+  pageSizes={activeTab.pageSizes}
+  onScrollToPage={(i) => viewerRef.current?.scrollToPage(i)}
+  onBugReport={openBugReportForError}
+  containerRef={sidebarRef}
+/>
+```
+
+---
+
+## Task 4 — `PageSidebar`: accept `containerRef`, use store anchor
+
+**Files:**
+- Modify: `src/components/PageSidebar.tsx`
+
+- [ ] **Step 4.1 — Add `containerRef` to `Props` and import `RefObject`**
+
+Replace the existing `Props` interface:
+
+```typescript
+interface Props {
+  docId: number;
+  pageSizes: PageSize[];
+  onScrollToPage(index: number): void;
+  onBugReport(message: string): void;
+}
+```
+
+with:
+
+```typescript
+import type { RefObject } from "react";
+
+interface Props {
+  docId: number;
+  pageSizes: PageSize[];
+  onScrollToPage(index: number): void;
+  onBugReport(message: string): void;
+  containerRef?: RefObject<HTMLDivElement | null>;
+}
+```
+
+Note: add the `RefObject` import to the existing `react` import line:
+
+```typescript
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+```
+
+- [ ] **Step 4.2 — Replace `anchorRef` with store `selectionAnchor`**
+
+In the function signature, add the new prop:
+
+```typescript
+export function PageSidebar({ docId, pageSizes, onScrollToPage, onBugReport, containerRef: externalRef }: Props) {
+  const internalRef = useRef<HTMLDivElement>(null);
+  const containerRef = externalRef ?? internalRef;
+```
+
+Remove the `anchorRef` line:
+```typescript
+// DELETE this line:
+const anchorRef = useRef(0);
+```
+
+Add store selectors for `selectionAnchor` and `setSelectionAnchor` alongside the existing ones:
+
+```typescript
+const selectedPages = useAppStore((s) => s.selectedPages);
+const togglePageSelection = useAppStore((s) => s.togglePageSelection);
+const selectPageRange = useAppStore((s) => s.selectPageRange);
+const clearSelection = useAppStore((s) => s.clearSelection);
+const setSelectionAnchor = useAppStore((s) => s.setSelectionAnchor);
+```
+
+- [ ] **Step 4.3 — Update `handleThumbClick` to use store anchor**
+
+Replace the existing `handleThumbClick`:
+
+```typescript
+const handleThumbClick = useCallback(
+  (index: number, e: React.MouseEvent) => {
+    if (e.metaKey || e.ctrlKey) {
+      const isAdding = !useAppStore.getState().selectedPages.has(index);
+      togglePageSelection(index);
+      if (isAdding) setSelectionAnchor(index);
+    } else if (e.shiftKey) {
+      const anchor = useAppStore.getState().selectionAnchor ?? index;
+      selectPageRange(anchor, index);
+    } else {
+      clearSelection();
+      setSelectionAnchor(index);
+      onScrollToPage(index);
+    }
+  },
+  [togglePageSelection, selectPageRange, clearSelection, setSelectionAnchor, onScrollToPage]
+);
+```
+
+- [ ] **Step 4.4 — Attach `containerRef` to the scroll div**
+
+Find the inner scroll div:
+
+```tsx
+<div ref={containerRef} className="h-full overflow-y-auto py-2 pl-3 pr-6">
+```
+
+This line already uses `containerRef` — it now uses the merged ref (external ?? internal), so no change needed here as long as step 4.2 renamed the variable correctly.
+
+- [ ] **Step 4.5 — Run tests**
+
+```bash
+make test-frontend
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4.6 — Commit**
+
+```bash
+git add src/App.tsx src/components/PageSidebar.tsx
+git commit -m "feat: wire useKeyboardNav hook and sidebarRef in App"
+```
+
+---
+
+## Task 5 — `ShortcutOverlay`: two-column layout + Page Navigation section
+
+**Files:**
+- Modify: `src/components/ShortcutOverlay.tsx`
+
+- [ ] **Step 5.1 — Update `ShortcutOverlay.tsx`**
+
+Replace the entire file contents with:
+
+```typescript
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { isMac, modKey, shiftModKey } from "@/lib/platform";
+
+interface Props {
+  open: boolean;
+  onClose(): void;
+}
+
+interface SingleRow {
+  action: string;
+  keys: string[];
+}
+
+interface DualRow {
+  action: string;
+  standard: string | null;
+  vim: string | null;
+}
+
+interface SingleSection {
+  kind: "single";
+  label: string;
+  rows: SingleRow[];
+}
+
+interface DualSection {
+  kind: "dual";
+  label: string;
+  rows: DualRow[];
+}
+
+type Section = SingleSection | DualSection;
+
+function buildSections(): Section[] {
+  const mod = modKey();
+  const shiftMod = shiftModKey();
+  return [
+    {
+      kind: "single",
+      label: "File",
+      rows: [
+        { action: "Open PDF", keys: [`${mod}O`] },
+        { action: "Save",     keys: [`${mod}S`] },
+        { action: "Save As",  keys: [`${shiftMod}S`] },
+        { action: "Close",    keys: [`${mod}W`] },
+      ],
+    },
+    {
+      kind: "dual",
+      label: "Page Navigation",
+      rows: [
+        { action: "Next page",     standard: "PgDn", vim: "j" },
+        { action: "Previous page", standard: "PgUp",  vim: "k" },
+        { action: "First page",    standard: "Home",  vim: "gg" },
+        { action: "Last page",     standard: "End",   vim: "G" },
+      ],
+    },
+    {
+      kind: "single",
+      label: "View",
+      rows: [
+        { action: "Document Info",  keys: [`${mod}I`] },
+        { action: "Zoom In",        keys: [`${mod}+`] },
+        { action: "Zoom Out",       keys: [`${mod}−`] },
+        { action: "Fit Width",      keys: [`${mod}0`] },
+        { action: "Toggle Sidebar", keys: [`${mod}B`] },
+      ],
+    },
+    {
+      kind: "single",
+      label: "Tabs",
+      rows: [
+        {
+          action: "Next Tab",
+          keys: isMac ? ["⌘⇧]"] : ["Ctrl+Tab", "Ctrl+PgDn"],
+        },
+        {
+          action: "Previous Tab",
+          keys: isMac ? ["⌘⇧["] : ["Ctrl+Shift+Tab", "Ctrl+PgUp"],
+        },
+        {
+          action: "Jump to Tab",
+          keys: [`${mod}1 – ${mod}9`],
+        },
+      ],
+    },
+    {
+      kind: "dual",
+      label: "Selection",
+      rows: [
+        { action: "Select All",    standard: `${mod}A`, vim: null },
+        { action: "Expand down",   standard: "⇧↓",      vim: "⇧j" },
+        { action: "Expand up",     standard: "⇧↑",      vim: "⇧k" },
+      ],
+    },
+    {
+      kind: "single",
+      label: "Help",
+      rows: [
+        { action: "Keyboard Shortcuts", keys: ["?"] },
+      ],
+    },
+  ];
+}
+
+function Kbd({ children }: { children: string }) {
+  return (
+    <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-xs">
+      {children}
+    </kbd>
+  );
+}
+
+function SingleSectionView({ section }: { section: SingleSection }) {
+  return (
+    <div>
+      <p className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {section.label}
+      </p>
+      <div className="space-y-1">
+        {section.rows.map((row) => (
+          <div key={row.action} className="flex items-center justify-between text-sm">
+            <span>{row.action}</span>
+            <div className="flex items-center gap-1">
+              {row.keys.map((k) => <Kbd key={k}>{k}</Kbd>)}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DualSectionView({ section }: { section: DualSection }) {
+  return (
+    <div>
+      <p className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {section.label}
+      </p>
+      {/* Column headers */}
+      <div className="mb-1 grid grid-cols-[1fr_88px_56px] gap-x-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+        <span />
+        <span className="text-right">Standard</span>
+        <span className="text-right">Vim</span>
+      </div>
+      <div className="space-y-1">
+        {section.rows.map((row) => (
+          <div
+            key={row.action}
+            className="grid grid-cols-[1fr_88px_56px] items-center gap-x-2 text-sm"
+          >
+            <span>{row.action}</span>
+            <div className="flex justify-end">
+              {row.standard ? <Kbd>{row.standard}</Kbd> : <span className="text-muted-foreground/40">—</span>}
+            </div>
+            <div className="flex justify-end">
+              {row.vim ? <Kbd>{row.vim}</Kbd> : <span className="text-muted-foreground/40">—</span>}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ShortcutOverlay({ open, onClose }: Props) {
+  const sections = buildSections();
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => { if (!next) onClose(); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Keyboard Shortcuts</DialogTitle>
+        </DialogHeader>
+
+        <div className="mt-2 space-y-5">
+          {sections.map((section) =>
+            section.kind === "dual" ? (
+              <DualSectionView key={section.label} section={section} />
+            ) : (
+              <SingleSectionView key={section.label} section={section} />
+            )
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 5.2 — Run tests**
+
+```bash
+make test-frontend
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5.3 — Commit**
+
+```bash
+git add src/components/ShortcutOverlay.tsx
+git commit -m "feat: shortcut overlay — Page Navigation section, two-column Vim layout"
+```
+
+---
+
+## Verification
+
+- [ ] `make test-frontend` — all tests green
+- [ ] `cargo tauri dev` — open a multi-page PDF
+- [ ] Press `j` / `k` — pages advance / retreat one at a time
+- [ ] Press `PgDn` / `PgUp` — same behaviour
+- [ ] Press `gg` (two g presses within ~500ms) — jumps to page 1
+- [ ] Press `G` — jumps to last page; press `End` — same
+- [ ] Press `Home` — jumps to first page
+- [ ] Click into an address bar or any future text input; press `j` — no navigation
+- [ ] Click a thumbnail to focus the sidebar; press `J` (Shift+j) — selection expands downward; press `K` — selection expands upward
+- [ ] Press `⇧↓` and `⇧↑` with sidebar focused — same expansion behaviour
+- [ ] Switch tabs while sidebar has a selection — return to the original tab, anchor is still correct
+- [ ] Press `?` — overlay shows "Page Navigation" section with Standard/Vim columns; "Navigation" is now "Tabs"; Selection section has Expand down/up rows
+- [ ] Press `Escape` — overlay dismisses

--- a/docs/superpowers/specs/2026-04-18-keyboard-navigation-design.md
+++ b/docs/superpowers/specs/2026-04-18-keyboard-navigation-design.md
@@ -1,0 +1,100 @@
+# Keyboard Navigation Design (Issue #7)
+
+## Context
+
+Collate's design principle is "mouse and keyboard are equals." Phase 1 milestone 7 requires full Vim-style page navigation (j/k, gg/G) with standard fallbacks (PgUp/PgDn, Home/End), plus a shortcut reference overlay on `?`. The overlay component and `?` binding already exist; no page navigation keys are wired yet.
+
+## Architecture
+
+All keyboard handling lives in a single hook: `src/hooks/useKeyboardNav.ts`. It is called once from `App.tsx` and attaches one `window` keydown listener. This is the single place to look for all keyboard navigation behaviour — no keyboard logic in individual components.
+
+The hook receives two refs:
+- `pageViewerRef` — the existing `PageViewerHandle` ref (exposes `scrollToPage`)
+- `sidebarRef` — a `RefObject<HTMLElement>` pointing to the sidebar container (new, threaded from `App.tsx` → `PageSidebar`)
+
+## Focus Guards
+
+Two guards, applied per-binding:
+
+- **Global guard** — skip if `event.target` is an `<input>`, `<textarea>`, `<select>`, or has `contentEditable === "true"`. Prevents bindings firing when the user is typing.
+- **Sidebar guard** — Shift+↑/↓/j/k only fire when `sidebarRef.current?.contains(document.activeElement)` is true. Prevents selection expansion when the viewer or another element has focus.
+
+## Bindings
+
+| Action | Standard | Vim | Guard |
+|--------|----------|-----|-------|
+| Next page | PgDn | j | global |
+| Previous page | PgUp | k | global |
+| First page | Home | gg | global |
+| Last page | End | G | global |
+| Expand selection down | Shift+↓ | Shift+j | sidebar focused |
+| Expand selection up | Shift+↑ | Shift+k | sidebar focused |
+
+Page bounds are clamped: next page stops at `pageCount - 1`, previous stops at `0`.
+
+## `gg` Detection
+
+A `useRef<number>` holds the timestamp of the last `g` keypress. On each `g`, if the previous press was within 500 ms, trigger first-page jump and reset the ref. Otherwise record the timestamp.
+
+## Selection Anchor
+
+Expanding selection with keyboard requires a stable anchor (the page where selection started). Add to the zustand store:
+
+```ts
+selectionAnchor: number | null        // index of anchor page, null when no selection
+setSelectionAnchor: (i: number | null) => void
+```
+
+The anchor is stored in the zustand store (not a local ref) so it survives tab switches. When `clearSelection` is called, `selectionAnchor` is also reset to `null`.
+
+Anchor is set to the clicked page on a **plain click** (no modifier) in `PageSidebar`. On Shift+click (range selection) the anchor is left unchanged — the clicked page becomes the range end, not the new anchor. On Ctrl/Cmd+click (toggle), the anchor is updated to the toggled page only if it is being added (not removed).
+
+Shift+↑/↓/j/k call `selectPageRange(selectionAnchor, newCursor)` using the existing store action.
+
+## ShortcutOverlay Changes
+
+`ShortcutOverlay.tsx` receives two changes:
+
+1. **New "Page Navigation" section** inserted after "File", using the two-column Standard/Vim layout:
+
+   | Action | Standard | Vim |
+   |--------|----------|-----|
+   | Next page | PgDn | j |
+   | Previous page | PgUp | k |
+   | First page | Home | gg |
+   | Last page | End | G |
+
+2. **"Navigation" section renamed to "Tabs"** to distinguish from page navigation.
+
+3. **Selection section gains two new rows** using the same two-column layout:
+
+   | Action | Standard | Vim |
+   |--------|----------|-----|
+   | Select All | ⌘A | — |
+   | Expand down | Shift+↓ | Shift+j |
+   | Expand up | Shift+↑ | Shift+k |
+
+The two-column layout uses fixed-width wrapper divs (`display:flex; justify-content:flex-end`) so column alignment holds without stretching the `<kbd>` chips.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/hooks/useKeyboardNav.ts` | **new** — all keyboard nav logic |
+| `src/App.tsx` | call `useKeyboardNav`, thread `sidebarRef` to `PageSidebar` |
+| `src/store.ts` | add `selectionAnchor`, `setSelectionAnchor`; reset anchor in `clearSelection` |
+| `src/components/ShortcutOverlay.tsx` | add Page Navigation section, rename Navigation→Tabs, add selection rows |
+| `src/components/PageSidebar.tsx` | accept and forward `sidebarRef` prop; call `setSelectionAnchor` on first selection |
+
+## Verification
+
+1. `make test-frontend` — all existing tests pass
+2. Open a PDF, click the viewer area, press `j`/`k` — pages advance/retreat
+3. Press `PgDn`/`PgUp` — same behaviour
+4. Press `gg` (two g's within 500ms) — jumps to page 1
+5. Press `G` / `End` — jumps to last page
+6. Click a text input (e.g. any future search field), press `j` — no navigation fires
+7. Click a sidebar thumbnail to focus sidebar, Shift+↓ — selection expands downward; Shift+↑ contracts/expands upward
+8. Switch tabs while sidebar selection is active — anchor survives, expansion continues correctly on return
+9. Press `?` — overlay shows Page Navigation section with correct two-column layout
+10. Press `Escape` or `?` again — overlay dismisses

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/sidebar";
 import { useAppStore, ZOOM_STEPS, PageDisplay, TabEntry } from "@/store";
 import { useTheme } from "@/hooks/useTheme";
+import { useKeyboardNav } from "@/hooks/useKeyboardNav";
 import { platformName } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import type { DocumentManifest } from "@/types";
@@ -37,6 +38,7 @@ function App() {
   const viewerRef = useRef<PageViewerHandle>(null);
   // Stable ref for use inside event listener closures
   const activeTabRef = useRef<TabEntry | null>(null);
+  const sidebarRef = useRef<HTMLDivElement>(null);
 
   const tabs = useAppStore((s) => s.tabs);
   const activeDocId = useAppStore((s) => s.activeDocId);
@@ -52,6 +54,7 @@ function App() {
 
   // Apply theme (dark class on <html>) and keep it in sync with OS changes
   useTheme();
+  useKeyboardNav({ pageViewerRef: viewerRef, sidebarRef });
 
   // Keep ref in sync so event listeners always see the current active tab
   useEffect(() => { activeTabRef.current = activeTab; }, [activeTab]);
@@ -392,6 +395,7 @@ function App() {
             pageSizes={activeTab.pageSizes}
             onScrollToPage={(i) => viewerRef.current?.scrollToPage(i)}
             onBugReport={openBugReportForError}
+            containerRef={sidebarRef}
           />
         </Sidebar>
       )}

--- a/src/components/PageSidebar.tsx
+++ b/src/components/PageSidebar.tsx
@@ -59,6 +59,7 @@ export function PageSidebar({ docId, pageSizes, onScrollToPage, onBugReport, con
         setSelectionAnchor(index);
         onScrollToPage(index);
       }
+      containerRef.current?.focus();
     },
     [togglePageSelection, selectPageRange, clearSelection, setSelectionAnchor, onScrollToPage]
   );
@@ -112,7 +113,7 @@ export function PageSidebar({ docId, pageSizes, onScrollToPage, onBugReport, con
       </SidebarHeader>
       <SidebarContent className="overflow-hidden p-0">
         {/* containerRef drives both ResizeObserver and the virtualizer. */}
-        <div ref={containerRef} className="h-full overflow-y-auto py-2 pl-3 pr-6">
+        <div ref={containerRef} tabIndex={-1} className="h-full overflow-y-auto py-2 pl-3 pr-6 focus:outline-none">
           <div
             className="relative w-full"
             style={{ height: thumbVirtualizer.getTotalSize() }}

--- a/src/components/PageSidebar.tsx
+++ b/src/components/PageSidebar.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   SidebarContent,
@@ -18,6 +19,7 @@ interface Props {
   pageSizes: PageSize[];
   onScrollToPage(index: number): void;
   onBugReport(message: string): void;
+  containerRef?: RefObject<HTMLDivElement | null>;
 }
 
 /** Gap between thumbnails in pixels. */
@@ -32,32 +34,33 @@ const THUMBNAIL_GAP = 16;
  * width — including after the user resizes the window. The same ref drives
  * both the observer and the virtualizer's scroll container.
  */
-export function PageSidebar({ docId, pageSizes, onScrollToPage, onBugReport }: Props) {
-  const containerRef = useRef<HTMLDivElement>(null);
+export function PageSidebar({ docId, pageSizes, onScrollToPage, onBugReport, containerRef: externalRef }: Props) {
+  const internalRef = useRef<HTMLDivElement>(null);
+  const containerRef = externalRef ?? internalRef;
   const [thumbnailWidth, setThumbnailWidth] = useState(120);
-
-  // Range-select anchor — tracked in a ref to avoid re-renders.
-  const anchorRef = useRef(0);
 
   const selectedPages = useAppStore((s) => s.selectedPages);
   const togglePageSelection = useAppStore((s) => s.togglePageSelection);
   const selectPageRange = useAppStore((s) => s.selectPageRange);
   const clearSelection = useAppStore((s) => s.clearSelection);
+  const setSelectionAnchor = useAppStore((s) => s.setSelectionAnchor);
 
   const handleThumbClick = useCallback(
     (index: number, e: React.MouseEvent) => {
       if (e.metaKey || e.ctrlKey) {
+        const isAdding = !useAppStore.getState().selectedPages.has(index);
         togglePageSelection(index);
-        anchorRef.current = index;
+        if (isAdding) setSelectionAnchor(index);
       } else if (e.shiftKey) {
-        selectPageRange(anchorRef.current, index);
+        const anchor = useAppStore.getState().selectionAnchor ?? index;
+        selectPageRange(anchor, index);
       } else {
         clearSelection();
+        setSelectionAnchor(index);
         onScrollToPage(index);
-        anchorRef.current = index;
       }
     },
-    [togglePageSelection, selectPageRange, clearSelection, onScrollToPage]
+    [togglePageSelection, selectPageRange, clearSelection, setSelectionAnchor, onScrollToPage]
   );
 
   // Measure available content width and update thumbnails when it changes.

--- a/src/components/PageViewer.test.tsx
+++ b/src/components/PageViewer.test.tsx
@@ -113,10 +113,12 @@ describe("PageViewer — scrollToPage", () => {
     expect(useAppStore.getState().activePage).toBe(10); // page 11, NOT page 13 (index 12)
   });
 
-  it("scrollToPage sets scrollTop at the page's top edge including PAGE_TOP_GAP offset", async () => {
+  it("scrollToPage sets scrollTop so the target page has PAGE_TOP_GAP above it", async () => {
     // At 75% zoom: pageWidth = round(612*75/100) = 459, rendered_h = round(792/612*459) = 594, slot = 610.
     // Page 1 top in DOM = PAGE_TOP_GAP + slot0 = 16 + 610 = 626.
-    // scrollToPage(1) must set scrollTop = 626 so the page aligns to the viewport top.
+    // scrollToPage(1) must set scrollTop = 610 (= slot0) so the viewport starts at 610,
+    // leaving PAGE_TOP_GAP (16 px) of breathing room above page 1 — matching the gap
+    // that exists above page 0 when a document first opens (scrollTop = 0).
     const ref = createRef<PageViewerHandle>();
     const { container } = render(<PageViewer ref={ref} docId={1} pageSizes={PAGES_5} />);
     const scrollEl = container.firstElementChild as HTMLDivElement;
@@ -125,7 +127,7 @@ describe("PageViewer — scrollToPage", () => {
       ref.current?.scrollToPage(1);
     });
 
-    expect(scrollEl.scrollTop).toBe(626);
+    expect(scrollEl.scrollTop).toBe(610);
   });
 });
 

--- a/src/components/PageViewer.tsx
+++ b/src/components/PageViewer.tsx
@@ -193,7 +193,7 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
       scrollToPage(index) {
         const el = parentRef.current;
         if (!el) return;
-        let offset = 0;
+        let offset = PAGE_TOP_GAP;
         for (let i = 0; i < index; i++) {
           const { width_pts, height_pts } = pageSizes[i];
           offset += Math.round((height_pts / width_pts) * pageWidthFor(width_pts)) + PAGE_GAP;

--- a/src/components/PageViewer.tsx
+++ b/src/components/PageViewer.tsx
@@ -193,7 +193,7 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
       scrollToPage(index) {
         const el = parentRef.current;
         if (!el) return;
-        let offset = PAGE_TOP_GAP;
+        let offset = 0;
         for (let i = 0; i < index; i++) {
           const { width_pts, height_pts } = pageSizes[i];
           offset += Math.round((height_pts / width_pts) * pageWidthFor(width_pts)) + PAGE_GAP;

--- a/src/components/PageViewer.tsx
+++ b/src/components/PageViewer.tsx
@@ -21,8 +21,8 @@ export interface PageViewerHandle {
 /** Gap between pages in pixels. */
 const PAGE_GAP = 16;
 
-/** Extra space above the first page so content isn't cramped against the tab bar. */
-const PAGE_TOP_GAP = 28;
+/** Extra space above the first page — matches PAGE_GAP for visual consistency. */
+const PAGE_TOP_GAP = PAGE_GAP;
 
 /** Horizontal padding around pages in fit-width mode (16px each side). */
 const PAGE_PADDING_X = 32;
@@ -193,7 +193,7 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
       scrollToPage(index) {
         const el = parentRef.current;
         if (!el) return;
-        let offset = PAGE_TOP_GAP;
+        let offset = 0;
         for (let i = 0; i < index; i++) {
           const { width_pts, height_pts } = pageSizes[i];
           offset += Math.round((height_pts / width_pts) * pageWidthFor(width_pts)) + PAGE_GAP;

--- a/src/components/PageViewer.tsx
+++ b/src/components/PageViewer.tsx
@@ -21,8 +21,8 @@ export interface PageViewerHandle {
 /** Gap between pages in pixels. */
 const PAGE_GAP = 16;
 
-/** Extra space above the first page — matches PAGE_GAP for visual consistency. */
-const PAGE_TOP_GAP = PAGE_GAP;
+/** Extra space above the first page so content isn't cramped against the tab bar. */
+const PAGE_TOP_GAP = 28;
 
 /** Horizontal padding around pages in fit-width mode (16px each side). */
 const PAGE_PADDING_X = 32;

--- a/src/components/ShortcutOverlay.test.tsx
+++ b/src/components/ShortcutOverlay.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ShortcutOverlay } from "./ShortcutOverlay";
+
+vi.mock("@/lib/platform", () => ({
+  isMac: false,
+  modKey: () => "Ctrl+",
+  shiftModKey: () => "Ctrl+Shift+",
+  platformName: "Linux",
+}));
+
+describe("ShortcutOverlay — platform-aware key labels", () => {
+  it("shows Shift+↓ and Shift+↑ for selection expansion on non-Mac", () => {
+    render(<ShortcutOverlay open={true} onClose={() => {}} />);
+    expect(screen.getByText("Shift+↓")).toBeInTheDocument();
+    expect(screen.getByText("Shift+↑")).toBeInTheDocument();
+  });
+
+  it("does not show Mac-only ⇧↓ or ⇧↑ glyphs on non-Mac", () => {
+    render(<ShortcutOverlay open={true} onClose={() => {}} />);
+    expect(screen.queryByText("⇧↓")).not.toBeInTheDocument();
+    expect(screen.queryByText("⇧↑")).not.toBeInTheDocument();
+  });
+
+  it("shows J and K as vim selection expansion labels", () => {
+    render(<ShortcutOverlay open={true} onClose={() => {}} />);
+    expect(screen.getByText("J")).toBeInTheDocument();
+    expect(screen.getByText("K")).toBeInTheDocument();
+  });
+
+  it("does not show Mac-only ⇧j or ⇧k glyphs on non-Mac", () => {
+    render(<ShortcutOverlay open={true} onClose={() => {}} />);
+    expect(screen.queryByText("⇧j")).not.toBeInTheDocument();
+    expect(screen.queryByText("⇧k")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ShortcutOverlay.tsx
+++ b/src/components/ShortcutOverlay.tsx
@@ -11,30 +11,57 @@ interface Props {
   onClose(): void;
 }
 
-interface ShortcutRow {
+interface SingleRow {
   action: string;
   keys: string[];
 }
 
-interface Section {
-  label: string;
-  rows: ShortcutRow[];
+interface DualRow {
+  action: string;
+  standard: string | null;
+  vim: string | null;
 }
+
+interface SingleSection {
+  kind: "single";
+  label: string;
+  rows: SingleRow[];
+}
+
+interface DualSection {
+  kind: "dual";
+  label: string;
+  rows: DualRow[];
+}
+
+type Section = SingleSection | DualSection;
 
 function buildSections(): Section[] {
   const mod = modKey();
   const shiftMod = shiftModKey();
   return [
     {
+      kind: "single",
       label: "File",
       rows: [
-        { action: "Open PDF",  keys: [`${mod}O`] },
-        { action: "Save",      keys: [`${mod}S`] },
-        { action: "Save As",   keys: [`${shiftMod}S`] },
-        { action: "Close",     keys: [`${mod}W`] },
+        { action: "Open PDF", keys: [`${mod}O`] },
+        { action: "Save",     keys: [`${mod}S`] },
+        { action: "Save As",  keys: [`${shiftMod}S`] },
+        { action: "Close",    keys: [`${mod}W`] },
       ],
     },
     {
+      kind: "dual",
+      label: "Page Navigation",
+      rows: [
+        { action: "Next page",     standard: "PgDn", vim: "j" },
+        { action: "Previous page", standard: "PgUp",  vim: "k" },
+        { action: "First page",    standard: "Home",  vim: "gg" },
+        { action: "Last page",     standard: "End",   vim: "G" },
+      ],
+    },
+    {
+      kind: "single",
       label: "View",
       rows: [
         { action: "Document Info",  keys: [`${mod}I`] },
@@ -45,7 +72,8 @@ function buildSections(): Section[] {
       ],
     },
     {
-      label: "Navigation",
+      kind: "single",
+      label: "Tabs",
       rows: [
         {
           action: "Next Tab",
@@ -62,18 +90,82 @@ function buildSections(): Section[] {
       ],
     },
     {
+      kind: "dual",
       label: "Selection",
       rows: [
-        { action: "Select All Pages", keys: [`${mod}A`] },
+        { action: "Select All",    standard: `${mod}A`, vim: null },
+        { action: "Expand down",   standard: "⇧↓",      vim: "⇧j" },
+        { action: "Expand up",     standard: "⇧↑",      vim: "⇧k" },
       ],
     },
     {
+      kind: "single",
       label: "Help",
       rows: [
         { action: "Keyboard Shortcuts", keys: ["?"] },
       ],
     },
   ];
+}
+
+function Kbd({ children }: { children: string }) {
+  return (
+    <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-xs">
+      {children}
+    </kbd>
+  );
+}
+
+function SingleSectionView({ section }: { section: SingleSection }) {
+  return (
+    <div>
+      <p className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {section.label}
+      </p>
+      <div className="space-y-1">
+        {section.rows.map((row) => (
+          <div key={row.action} className="flex items-center justify-between text-sm">
+            <span>{row.action}</span>
+            <div className="flex items-center gap-1">
+              {row.keys.map((k) => <Kbd key={k}>{k}</Kbd>)}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DualSectionView({ section }: { section: DualSection }) {
+  return (
+    <div>
+      <p className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {section.label}
+      </p>
+      {/* Column headers */}
+      <div className="mb-1 grid grid-cols-[1fr_88px_56px] gap-x-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+        <span />
+        <span className="text-right">Standard</span>
+        <span className="text-right">Vim</span>
+      </div>
+      <div className="space-y-1">
+        {section.rows.map((row) => (
+          <div
+            key={row.action}
+            className="grid grid-cols-[1fr_88px_56px] items-center gap-x-2 text-sm"
+          >
+            <span>{row.action}</span>
+            <div className="flex justify-end">
+              {row.standard ? <Kbd>{row.standard}</Kbd> : <span className="text-muted-foreground/40">—</span>}
+            </div>
+            <div className="flex justify-end">
+              {row.vim ? <Kbd>{row.vim}</Kbd> : <span className="text-muted-foreground/40">—</span>}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 export function ShortcutOverlay({ open, onClose }: Props) {
@@ -87,30 +179,13 @@ export function ShortcutOverlay({ open, onClose }: Props) {
         </DialogHeader>
 
         <div className="mt-2 space-y-5">
-          {sections.map((section) => (
-            <div key={section.label}>
-              <p className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                {section.label}
-              </p>
-              <div className="space-y-1">
-                {section.rows.map((row) => (
-                  <div key={row.action} className="flex items-center justify-between text-sm">
-                    <span>{row.action}</span>
-                    <div className="flex items-center gap-1">
-                      {row.keys.map((k) => (
-                        <kbd
-                          key={k}
-                          className="rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-xs"
-                        >
-                          {k}
-                        </kbd>
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ))}
+          {sections.map((section) =>
+            section.kind === "dual" ? (
+              <DualSectionView key={section.label} section={section} />
+            ) : (
+              <SingleSectionView key={section.label} section={section} />
+            )
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/ShortcutOverlay.tsx
+++ b/src/components/ShortcutOverlay.tsx
@@ -143,6 +143,7 @@ function DualSectionView({ section }: { section: DualSection }) {
         {section.label}
       </p>
       {/* Column headers */}
+      {/* grid-cols must match data row below */}
       <div className="mb-1 grid grid-cols-[1fr_88px_56px] gap-x-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
         <span />
         <span className="text-right">Standard</span>
@@ -154,6 +155,7 @@ function DualSectionView({ section }: { section: DualSection }) {
             key={row.action}
             className="grid grid-cols-[1fr_88px_56px] items-center gap-x-2 text-sm"
           >
+            {/* grid-cols must match header row above */}
             <span>{row.action}</span>
             <div className="flex justify-end">
               {row.standard ? <Kbd>{row.standard}</Kbd> : <span className="text-muted-foreground/40">—</span>}

--- a/src/components/ShortcutOverlay.tsx
+++ b/src/components/ShortcutOverlay.tsx
@@ -175,12 +175,12 @@ export function ShortcutOverlay({ open, onClose }: Props) {
 
   return (
     <Dialog open={open} onOpenChange={(next) => { if (!next) onClose(); }}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md flex flex-col max-h-[calc(100dvh-2rem)]">
         <DialogHeader>
           <DialogTitle>Keyboard Shortcuts</DialogTitle>
         </DialogHeader>
 
-        <div className="mt-2 space-y-5">
+        <div className="mt-2 space-y-5 flex-1 min-h-0 overflow-y-auto pr-4">
           {sections.map((section) =>
             section.kind === "dual" ? (
               <DualSectionView key={section.label} section={section} />

--- a/src/components/ShortcutOverlay.tsx
+++ b/src/components/ShortcutOverlay.tsx
@@ -93,9 +93,9 @@ function buildSections(): Section[] {
       kind: "dual",
       label: "Selection",
       rows: [
-        { action: "Select All",    standard: `${mod}A`, vim: null },
-        { action: "Expand down",   standard: "⇧↓",      vim: "⇧j" },
-        { action: "Expand up",     standard: "⇧↑",      vim: "⇧k" },
+        { action: "Select All",    standard: `${mod}A`,                  vim: null },
+        { action: "Expand down",   standard: isMac ? "⇧↓" : "Shift+↓", vim: "J" },
+        { action: "Expand up",     standard: isMac ? "⇧↑" : "Shift+↑", vim: "K" },
       ],
     },
     {

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -10,7 +10,7 @@ import {
   type DragEndEvent,
   type DragStartEvent,
 } from "@dnd-kit/core";
-import { restrictToHorizontalAxis } from "@dnd-kit/modifiers";
+import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
 import {
   SortableContext,
   horizontalListSortingStrategy,
@@ -75,7 +75,7 @@ function SortableTab({ tab, isActive, onSwitch, onClose }: SortableTabProps) {
         }
       }}
       className={cn(
-        "inline-flex items-center gap-1.5 px-3 h-7 text-sm font-medium whitespace-nowrap border-t-2 select-none cursor-grab active:cursor-grabbing transition-colors",
+        "inline-flex items-center gap-1.5 px-3.5 h-8 text-sm font-medium whitespace-nowrap border-t-2 select-none cursor-grab active:cursor-grabbing transition-colors",
         isDragging && "opacity-0",
         isActive
           ? "bg-muted text-foreground border-primary"
@@ -130,7 +130,7 @@ export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabB
     <DndContext
       sensors={sensors}
       collisionDetection={closestCenter}
-      modifiers={[restrictToHorizontalAxis]}
+      modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
@@ -139,7 +139,7 @@ export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabB
         <div
           role="tablist"
           aria-label="Open documents"
-          className="flex shrink-0 overflow-x-auto items-end bg-background pt-1 px-2 gap-[3px]"
+          className="flex shrink-0 overflow-x-auto items-end bg-background border-t border-border pt-1.5 px-2 gap-1"
         >
           {tabs.map((tab) => (
             <SortableTab
@@ -155,7 +155,7 @@ export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabB
 
       <DragOverlay dropAnimation={null}>
         {activeTab && (
-          <div className="inline-flex items-center gap-1.5 px-3 h-7 text-sm font-medium whitespace-nowrap border-t-2 bg-tab-inactive text-muted-foreground border-transparent cursor-grabbing shadow-md">
+          <div className="inline-flex items-center gap-1.5 px-3.5 h-8 text-sm font-medium whitespace-nowrap border-t-2 bg-muted text-foreground border-primary cursor-grabbing shadow-lg">
             <TabContent tab={activeTab} />
             <span className="ml-0.5 p-0.5">
               <X className="size-3" />

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -10,7 +10,7 @@ import {
   type DragEndEvent,
   type DragStartEvent,
 } from "@dnd-kit/core";
-import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
+import { restrictToHorizontalAxis } from "@dnd-kit/modifiers";
 import {
   SortableContext,
   horizontalListSortingStrategy,
@@ -75,7 +75,7 @@ function SortableTab({ tab, isActive, onSwitch, onClose }: SortableTabProps) {
         }
       }}
       className={cn(
-        "inline-flex items-center gap-1.5 px-3.5 h-8 text-sm font-medium whitespace-nowrap border-t-2 select-none cursor-grab active:cursor-grabbing transition-colors",
+        "inline-flex items-center gap-1.5 px-3 h-7 text-sm font-medium whitespace-nowrap border-t-2 select-none cursor-grab active:cursor-grabbing transition-colors",
         isDragging && "opacity-0",
         isActive
           ? "bg-muted text-foreground border-primary"
@@ -130,7 +130,7 @@ export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabB
     <DndContext
       sensors={sensors}
       collisionDetection={closestCenter}
-      modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
+      modifiers={[restrictToHorizontalAxis]}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
@@ -139,7 +139,7 @@ export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabB
         <div
           role="tablist"
           aria-label="Open documents"
-          className="flex shrink-0 overflow-x-auto items-end bg-background border-t border-border pt-1.5 px-2 gap-1"
+          className="flex shrink-0 overflow-x-auto items-end bg-background pt-1 px-2 gap-[3px]"
         >
           {tabs.map((tab) => (
             <SortableTab
@@ -155,7 +155,7 @@ export function TabBar({ tabs, activeDocId, onSwitch, onClose, onReorder }: TabB
 
       <DragOverlay dropAnimation={null}>
         {activeTab && (
-          <div className="inline-flex items-center gap-1.5 px-3.5 h-8 text-sm font-medium whitespace-nowrap border-t-2 bg-muted text-foreground border-primary cursor-grabbing shadow-lg">
+          <div className="inline-flex items-center gap-1.5 px-3 h-7 text-sm font-medium whitespace-nowrap border-t-2 bg-tab-inactive text-muted-foreground border-transparent cursor-grabbing shadow-md">
             <TabContent tab={activeTab} />
             <span className="ml-0.5 p-0.5">
               <X className="size-3" />

--- a/src/hooks/useKeyboardNav.test.ts
+++ b/src/hooks/useKeyboardNav.test.ts
@@ -54,6 +54,16 @@ describe("page navigation — no document open", () => {
     fireKey("j");
     expect(scrollToPage).not.toHaveBeenCalled();
   });
+
+  it("does not call scrollToPage when pageCount is 0", () => {
+    useAppStore.setState({
+      tabs: [{ ...useAppStore.getState().tabs[0], pageCount: 0 }],
+    });
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("j");
+    expect(scrollToPage).not.toHaveBeenCalled();
+  });
 });
 
 describe("page navigation — input guard", () => {

--- a/src/hooks/useKeyboardNav.test.ts
+++ b/src/hooks/useKeyboardNav.test.ts
@@ -94,6 +94,17 @@ describe("j / PageDown — next page", () => {
     expect(scrollToPage).toHaveBeenCalledWith(6);
   });
 
+  it("j focuses the sidebar container", () => {
+    const sidebarEl = document.createElement("div");
+    sidebarEl.setAttribute("tabindex", "-1");
+    document.body.appendChild(sidebarEl);
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("j");
+    expect(document.activeElement).toBe(sidebarEl);
+    document.body.removeChild(sidebarEl);
+  });
+
   it("j clamps at last page", () => {
     useAppStore.setState({ activePage: 9 }); // last page (pageCount=10)
     const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
@@ -116,6 +127,17 @@ describe("k / PageUp — previous page", () => {
     renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
     fireKey("PageUp");
     expect(scrollToPage).toHaveBeenCalledWith(4);
+  });
+
+  it("k focuses the sidebar container", () => {
+    const sidebarEl = document.createElement("div");
+    sidebarEl.setAttribute("tabindex", "-1");
+    document.body.appendChild(sidebarEl);
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("k");
+    expect(document.activeElement).toBe(sidebarEl);
+    document.body.removeChild(sidebarEl);
   });
 
   it("k clamps at first page", () => {
@@ -255,5 +277,49 @@ describe("selection expansion — sidebar guard", () => {
     const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
     expect(pages).toEqual([3, 4]);
     cleanup();
+  });
+
+  it("J pressed twice keeps original anchor and grows selection", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 5, selectionAnchor: null });
+    fireKey("J");
+    fireKey("J");
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([5, 6, 7]);
+    cleanup();
+  });
+
+  it("Shift+ArrowDown pressed twice keeps original anchor and grows selection", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 5, selectionAnchor: null });
+    fireKey("ArrowDown", { shiftKey: true });
+    fireKey("ArrowDown", { shiftKey: true });
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([5, 6, 7]);
+    cleanup();
+  });
+});
+
+describe("Escape — clear selection", () => {
+  it("Escape clears selectedPages and selectionAnchor", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ selectedPages: new Set([1, 2, 3]), selectionAnchor: 2 });
+    fireKey("Escape");
+    expect(useAppStore.getState().selectedPages.size).toBe(0);
+    expect(useAppStore.getState().selectionAnchor).toBeNull();
+    void scrollToPage; // unused
+  });
+
+  it("Escape is a no-op when nothing is selected", () => {
+    const { pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ selectedPages: new Set(), selectionAnchor: null });
+    fireKey("Escape");
+    expect(useAppStore.getState().selectedPages.size).toBe(0);
   });
 });

--- a/src/hooks/useKeyboardNav.test.ts
+++ b/src/hooks/useKeyboardNav.test.ts
@@ -112,6 +112,34 @@ describe("j / PageDown — next page", () => {
     fireKey("j");
     expect(scrollToPage).toHaveBeenCalledWith(9);
   });
+
+  it("j does not focus sidebar when sidebar ancestor has data-state=collapsed", () => {
+    const collapsed = document.createElement("div");
+    collapsed.dataset.state = "collapsed";
+    const sidebarEl = document.createElement("div");
+    sidebarEl.tabIndex = -1;
+    collapsed.appendChild(sidebarEl);
+    document.body.appendChild(collapsed);
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("j");
+    expect(document.activeElement).not.toBe(sidebarEl);
+    document.body.removeChild(collapsed);
+  });
+
+  it("j focuses sidebar when sidebar ancestor has data-state=expanded", () => {
+    const expanded = document.createElement("div");
+    expanded.dataset.state = "expanded";
+    const sidebarEl = document.createElement("div");
+    sidebarEl.tabIndex = -1;
+    expanded.appendChild(sidebarEl);
+    document.body.appendChild(expanded);
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("j");
+    expect(document.activeElement).toBe(sidebarEl);
+    document.body.removeChild(expanded);
+  });
 });
 
 describe("k / PageUp — previous page", () => {
@@ -146,6 +174,21 @@ describe("k / PageUp — previous page", () => {
     renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
     fireKey("k");
     expect(scrollToPage).toHaveBeenCalledWith(0);
+  });
+
+  it("k does not focus sidebar when sidebar ancestor has data-state=collapsed", () => {
+    useAppStore.setState({ activePage: 5 });
+    const collapsed = document.createElement("div");
+    collapsed.dataset.state = "collapsed";
+    const sidebarEl = document.createElement("div");
+    sidebarEl.tabIndex = -1;
+    collapsed.appendChild(sidebarEl);
+    document.body.appendChild(collapsed);
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("k");
+    expect(document.activeElement).not.toBe(sidebarEl);
+    document.body.removeChild(collapsed);
   });
 });
 
@@ -321,5 +364,15 @@ describe("Escape — clear selection", () => {
     useAppStore.setState({ selectedPages: new Set(), selectionAnchor: null });
     fireKey("Escape");
     expect(useAppStore.getState().selectedPages.size).toBe(0);
+  });
+
+  it("Escape does not call e.preventDefault()", () => {
+    const { pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ selectedPages: new Set([1, 2]), selectionAnchor: 1 });
+    const event = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true });
+    const spy = vi.spyOn(event, "preventDefault");
+    window.dispatchEvent(event);
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useKeyboardNav.test.ts
+++ b/src/hooks/useKeyboardNav.test.ts
@@ -1,0 +1,249 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useKeyboardNav } from "./useKeyboardNav";
+import { useAppStore } from "@/store";
+import type { DocumentManifest } from "@/types";
+
+// Minimal tab fixture
+const MANIFEST: DocumentManifest = {
+  doc_id: 1,
+  filename: "test.pdf",
+  path: "/test.pdf",
+  page_count: 10,
+  page_sizes: [],
+  can_undo: false,
+  can_redo: false,
+};
+
+function fireKey(key: string, extra: Partial<KeyboardEventInit> = {}) {
+  window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...extra }));
+}
+
+function makeRefs(sidebarEl?: HTMLElement | null) {
+  const scrollToPage = vi.fn();
+  const pageViewerRef = { current: { scrollToPage } } as any;
+  const sidebarRef = { current: sidebarEl ?? null } as any;
+  return { scrollToPage, pageViewerRef, sidebarRef };
+}
+
+beforeEach(() => {
+  useAppStore.setState({
+    tabs: [],
+    activeDocId: null,
+    docViewStates: new Map(),
+    activePage: 0,
+    zoom: 75,
+    zoomMode: "manual",
+    selectedPages: new Set(),
+    isDirty: false,
+    selectionAnchor: null,
+  });
+  useAppStore.getState().addTab(MANIFEST);
+  useAppStore.setState({ activePage: 5 }); // start mid-document
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("page navigation — no document open", () => {
+  it("does not call scrollToPage when activeDocId is null", () => {
+    useAppStore.setState({ activeDocId: null });
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("j");
+    expect(scrollToPage).not.toHaveBeenCalled();
+  });
+});
+
+describe("page navigation — input guard", () => {
+  it("does not fire when target is an <input>", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    // Dispatch from the input so e.target is naturally set to it and it bubbles to window
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "j", bubbles: true }));
+    expect(scrollToPage).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+  });
+});
+
+describe("j / PageDown — next page", () => {
+  it("j scrolls to activePage + 1", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("j");
+    expect(scrollToPage).toHaveBeenCalledWith(6);
+  });
+
+  it("PageDown scrolls to activePage + 1", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("PageDown");
+    expect(scrollToPage).toHaveBeenCalledWith(6);
+  });
+
+  it("j clamps at last page", () => {
+    useAppStore.setState({ activePage: 9 }); // last page (pageCount=10)
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("j");
+    expect(scrollToPage).toHaveBeenCalledWith(9);
+  });
+});
+
+describe("k / PageUp — previous page", () => {
+  it("k scrolls to activePage - 1", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("k");
+    expect(scrollToPage).toHaveBeenCalledWith(4);
+  });
+
+  it("PageUp scrolls to activePage - 1", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("PageUp");
+    expect(scrollToPage).toHaveBeenCalledWith(4);
+  });
+
+  it("k clamps at first page", () => {
+    useAppStore.setState({ activePage: 0 });
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("k");
+    expect(scrollToPage).toHaveBeenCalledWith(0);
+  });
+});
+
+describe("G / End — last page", () => {
+  it("G jumps to last page", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("G");
+    expect(scrollToPage).toHaveBeenCalledWith(9);
+  });
+
+  it("End jumps to last page", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("End");
+    expect(scrollToPage).toHaveBeenCalledWith(9);
+  });
+});
+
+describe("Home — first page", () => {
+  it("Home jumps to first page", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("Home");
+    expect(scrollToPage).toHaveBeenCalledWith(0);
+  });
+});
+
+describe("gg — first page", () => {
+  it("two g presses within 500ms jump to first page", () => {
+    vi.useFakeTimers();
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("g");
+    vi.advanceTimersByTime(400);
+    fireKey("g");
+    expect(scrollToPage).toHaveBeenCalledWith(0);
+  });
+
+  it("two g presses more than 500ms apart do not jump", () => {
+    vi.useFakeTimers();
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("g");
+    vi.advanceTimersByTime(501);
+    fireKey("g");
+    expect(scrollToPage).not.toHaveBeenCalled();
+  });
+
+  it("single g press does not jump", () => {
+    const { scrollToPage, pageViewerRef, sidebarRef } = makeRefs();
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    fireKey("g");
+    expect(scrollToPage).not.toHaveBeenCalled();
+  });
+});
+
+describe("selection expansion — sidebar guard", () => {
+  function makeSidebarSetup() {
+    const sidebarEl = document.createElement("div");
+    document.body.appendChild(sidebarEl);
+    const child = document.createElement("button");
+    child.setAttribute("tabindex", "0");
+    sidebarEl.appendChild(child);
+    child.focus();
+    return { sidebarEl, cleanup: () => document.body.removeChild(sidebarEl) };
+  }
+
+  it("J (Shift+j) does not fire when sidebar not focused", () => {
+    const { pageViewerRef, sidebarRef } = makeRefs(null);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ selectionAnchor: 5 });
+    fireKey("J");
+    expect(useAppStore.getState().selectedPages.size).toBe(0);
+  });
+
+  it("J (Shift+j) expands selection down when sidebar focused", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 5, selectionAnchor: 5 });
+    fireKey("J");
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([5, 6]);
+    expect(useAppStore.getState().activePage).toBe(6);
+    cleanup();
+  });
+
+  it("K (Shift+k) expands selection up when sidebar focused", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 5, selectionAnchor: 5 });
+    fireKey("K");
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([4, 5]);
+    expect(useAppStore.getState().activePage).toBe(4);
+    cleanup();
+  });
+
+  it("Shift+ArrowDown expands selection down when sidebar focused", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 5, selectionAnchor: 5 });
+    fireKey("ArrowDown", { shiftKey: true });
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([5, 6]);
+    cleanup();
+  });
+
+  it("Shift+ArrowUp expands selection up when sidebar focused", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 5, selectionAnchor: 5 });
+    fireKey("ArrowUp", { shiftKey: true });
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([4, 5]);
+    cleanup();
+  });
+
+  it("selection expansion uses activePage as fallback anchor when selectionAnchor is null", () => {
+    const { sidebarEl, cleanup } = makeSidebarSetup();
+    const { pageViewerRef, sidebarRef } = makeRefs(sidebarEl);
+    renderHook(() => useKeyboardNav({ pageViewerRef, sidebarRef }));
+    useAppStore.setState({ activePage: 3, selectionAnchor: null });
+    fireKey("J");
+    const pages = [...useAppStore.getState().selectedPages].sort((a, b) => a - b);
+    expect(pages).toEqual([3, 4]);
+    cleanup();
+  });
+});

--- a/src/hooks/useKeyboardNav.ts
+++ b/src/hooks/useKeyboardNav.ts
@@ -59,14 +59,14 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
       }
 
       // j — next page
-      if (e.key === "j" && !e.metaKey && !e.ctrlKey) {
+      if (e.key === "j" && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
         pageViewerRef.current?.scrollToPage(Math.min(activePage + 1, pageCount - 1));
         return;
       }
 
       // k — previous page
-      if (e.key === "k" && !e.metaKey && !e.ctrlKey) {
+      if (e.key === "k" && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
         pageViewerRef.current?.scrollToPage(Math.max(activePage - 1, 0));
         return;
@@ -76,11 +76,10 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
       if (e.key === "J" && !e.metaKey && !e.ctrlKey) {
         if (!sidebarFocused) return;
         e.preventDefault();
-        const { selectionAnchor } = useAppStore.getState();
-        const anchor = selectionAnchor ?? activePage;
+        const anchor = state.selectionAnchor ?? activePage;
         const cursor = Math.min(activePage + 1, pageCount - 1);
-        useAppStore.getState().setActivePage(cursor);
-        useAppStore.getState().selectPageRange(anchor, cursor);
+        state.setActivePage(cursor);
+        state.selectPageRange(anchor, cursor);
         return;
       }
 
@@ -88,11 +87,10 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
       if (e.key === "K" && !e.metaKey && !e.ctrlKey) {
         if (!sidebarFocused) return;
         e.preventDefault();
-        const { selectionAnchor } = useAppStore.getState();
-        const anchor = selectionAnchor ?? activePage;
+        const anchor = state.selectionAnchor ?? activePage;
         const cursor = Math.max(activePage - 1, 0);
-        useAppStore.getState().setActivePage(cursor);
-        useAppStore.getState().selectPageRange(anchor, cursor);
+        state.setActivePage(cursor);
+        state.selectPageRange(anchor, cursor);
         return;
       }
 
@@ -128,11 +126,10 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
       if (e.key === "ArrowDown" && e.shiftKey && !e.metaKey && !e.ctrlKey) {
         if (!sidebarFocused) return;
         e.preventDefault();
-        const { selectionAnchor } = useAppStore.getState();
-        const anchor = selectionAnchor ?? activePage;
+        const anchor = state.selectionAnchor ?? activePage;
         const cursor = Math.min(activePage + 1, pageCount - 1);
-        useAppStore.getState().setActivePage(cursor);
-        useAppStore.getState().selectPageRange(anchor, cursor);
+        state.setActivePage(cursor);
+        state.selectPageRange(anchor, cursor);
         return;
       }
 
@@ -140,11 +137,10 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
       if (e.key === "ArrowUp" && e.shiftKey && !e.metaKey && !e.ctrlKey) {
         if (!sidebarFocused) return;
         e.preventDefault();
-        const { selectionAnchor } = useAppStore.getState();
-        const anchor = selectionAnchor ?? activePage;
+        const anchor = state.selectionAnchor ?? activePage;
         const cursor = Math.max(activePage - 1, 0);
-        useAppStore.getState().setActivePage(cursor);
-        useAppStore.getState().selectPageRange(anchor, cursor);
+        state.setActivePage(cursor);
+        state.selectPageRange(anchor, cursor);
         return;
       }
     }

--- a/src/hooks/useKeyboardNav.ts
+++ b/src/hooks/useKeyboardNav.ts
@@ -62,6 +62,7 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
       if (e.key === "j" && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
         pageViewerRef.current?.scrollToPage(Math.min(activePage + 1, pageCount - 1));
+        sidebarRef.current?.focus();
         return;
       }
 
@@ -69,6 +70,7 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
       if (e.key === "k" && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
         pageViewerRef.current?.scrollToPage(Math.max(activePage - 1, 0));
+        sidebarRef.current?.focus();
         return;
       }
 
@@ -76,6 +78,7 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
       if (e.key === "J" && !e.metaKey && !e.ctrlKey) {
         if (!sidebarFocused) return;
         e.preventDefault();
+        if (state.selectionAnchor === null) state.setSelectionAnchor(activePage);
         const anchor = state.selectionAnchor ?? activePage;
         const cursor = Math.min(activePage + 1, pageCount - 1);
         state.setActivePage(cursor);
@@ -87,6 +90,7 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
       if (e.key === "K" && !e.metaKey && !e.ctrlKey) {
         if (!sidebarFocused) return;
         e.preventDefault();
+        if (state.selectionAnchor === null) state.setSelectionAnchor(activePage);
         const anchor = state.selectionAnchor ?? activePage;
         const cursor = Math.max(activePage - 1, 0);
         state.setActivePage(cursor);
@@ -126,6 +130,7 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
       if (e.key === "ArrowDown" && e.shiftKey && !e.metaKey && !e.ctrlKey) {
         if (!sidebarFocused) return;
         e.preventDefault();
+        if (state.selectionAnchor === null) state.setSelectionAnchor(activePage);
         const anchor = state.selectionAnchor ?? activePage;
         const cursor = Math.min(activePage + 1, pageCount - 1);
         state.setActivePage(cursor);
@@ -137,10 +142,18 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
       if (e.key === "ArrowUp" && e.shiftKey && !e.metaKey && !e.ctrlKey) {
         if (!sidebarFocused) return;
         e.preventDefault();
+        if (state.selectionAnchor === null) state.setSelectionAnchor(activePage);
         const anchor = state.selectionAnchor ?? activePage;
         const cursor = Math.max(activePage - 1, 0);
         state.setActivePage(cursor);
         state.selectPageRange(anchor, cursor);
+        return;
+      }
+
+      // Escape — clear selection
+      if (e.key === "Escape") {
+        e.preventDefault();
+        state.clearSelection();
         return;
       }
     }

--- a/src/hooks/useKeyboardNav.ts
+++ b/src/hooks/useKeyboardNav.ts
@@ -1,0 +1,155 @@
+import { useEffect, useRef } from "react";
+import type { RefObject } from "react";
+import { useAppStore } from "@/store";
+import type { PageViewerHandle } from "@/components/PageViewer";
+
+interface Options {
+  pageViewerRef: RefObject<PageViewerHandle | null>;
+  sidebarRef: RefObject<HTMLElement | null>;
+}
+
+function isInputFocused(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    target.contentEditable === "true"
+  );
+}
+
+export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
+  const lastGRef = useRef<number>(0);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (isInputFocused(e.target)) return;
+
+      const state = useAppStore.getState();
+      if (state.activeDocId === null) return;
+
+      const tab = state.tabs.find((t) => t.docId === state.activeDocId);
+      if (!tab || tab.pageCount === 0) return;
+
+      const { activePage } = state;
+      const pageCount = tab.pageCount;
+      const sidebarFocused =
+        sidebarRef.current != null &&
+        sidebarRef.current.contains(document.activeElement);
+
+      // gg — first page
+      if (e.key === "g" && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
+        const now = Date.now();
+        if (now - lastGRef.current <= 500) {
+          e.preventDefault();
+          pageViewerRef.current?.scrollToPage(0);
+          lastGRef.current = 0;
+        } else {
+          lastGRef.current = now;
+        }
+        return;
+      }
+
+      // G — last page
+      if (e.key === "G" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(pageCount - 1);
+        return;
+      }
+
+      // j — next page
+      if (e.key === "j" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(Math.min(activePage + 1, pageCount - 1));
+        return;
+      }
+
+      // k — previous page
+      if (e.key === "k" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(Math.max(activePage - 1, 0));
+        return;
+      }
+
+      // J (Shift+j) — expand selection down (sidebar only)
+      if (e.key === "J" && !e.metaKey && !e.ctrlKey) {
+        if (!sidebarFocused) return;
+        e.preventDefault();
+        const { selectionAnchor } = useAppStore.getState();
+        const anchor = selectionAnchor ?? activePage;
+        const cursor = Math.min(activePage + 1, pageCount - 1);
+        useAppStore.getState().setActivePage(cursor);
+        useAppStore.getState().selectPageRange(anchor, cursor);
+        return;
+      }
+
+      // K (Shift+k) — expand selection up (sidebar only)
+      if (e.key === "K" && !e.metaKey && !e.ctrlKey) {
+        if (!sidebarFocused) return;
+        e.preventDefault();
+        const { selectionAnchor } = useAppStore.getState();
+        const anchor = selectionAnchor ?? activePage;
+        const cursor = Math.max(activePage - 1, 0);
+        useAppStore.getState().setActivePage(cursor);
+        useAppStore.getState().selectPageRange(anchor, cursor);
+        return;
+      }
+
+      // PageDown — next page
+      if (e.key === "PageDown") {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(Math.min(activePage + 1, pageCount - 1));
+        return;
+      }
+
+      // PageUp — previous page
+      if (e.key === "PageUp") {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(Math.max(activePage - 1, 0));
+        return;
+      }
+
+      // Home — first page
+      if (e.key === "Home") {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(0);
+        return;
+      }
+
+      // End — last page
+      if (e.key === "End") {
+        e.preventDefault();
+        pageViewerRef.current?.scrollToPage(pageCount - 1);
+        return;
+      }
+
+      // Shift+ArrowDown — expand selection down (sidebar only)
+      if (e.key === "ArrowDown" && e.shiftKey && !e.metaKey && !e.ctrlKey) {
+        if (!sidebarFocused) return;
+        e.preventDefault();
+        const { selectionAnchor } = useAppStore.getState();
+        const anchor = selectionAnchor ?? activePage;
+        const cursor = Math.min(activePage + 1, pageCount - 1);
+        useAppStore.getState().setActivePage(cursor);
+        useAppStore.getState().selectPageRange(anchor, cursor);
+        return;
+      }
+
+      // Shift+ArrowUp — expand selection up (sidebar only)
+      if (e.key === "ArrowUp" && e.shiftKey && !e.metaKey && !e.ctrlKey) {
+        if (!sidebarFocused) return;
+        e.preventDefault();
+        const { selectionAnchor } = useAppStore.getState();
+        const anchor = selectionAnchor ?? activePage;
+        const cursor = Math.max(activePage - 1, 0);
+        useAppStore.getState().setActivePage(cursor);
+        useAppStore.getState().selectPageRange(anchor, cursor);
+        return;
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [pageViewerRef, sidebarRef]);
+}

--- a/src/hooks/useKeyboardNav.ts
+++ b/src/hooks/useKeyboardNav.ts
@@ -8,6 +8,11 @@ interface Options {
   sidebarRef: RefObject<HTMLElement | null>;
 }
 
+/** Returns true when el has no collapsed sidebar ancestor (shadcn sets data-state="collapsed" on the aside). */
+function isSidebarVisible(el: HTMLElement): boolean {
+  return el.closest('[data-state="collapsed"]') === null;
+}
+
 function isInputFocused(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
   const tag = target.tagName;
@@ -62,7 +67,9 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
       if (e.key === "j" && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
         pageViewerRef.current?.scrollToPage(Math.min(activePage + 1, pageCount - 1));
-        sidebarRef.current?.focus();
+        if (sidebarRef.current && isSidebarVisible(sidebarRef.current)) {
+          sidebarRef.current.focus();
+        }
         return;
       }
 
@@ -70,7 +77,9 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
       if (e.key === "k" && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
         pageViewerRef.current?.scrollToPage(Math.max(activePage - 1, 0));
-        sidebarRef.current?.focus();
+        if (sidebarRef.current && isSidebarVisible(sidebarRef.current)) {
+          sidebarRef.current.focus();
+        }
         return;
       }
 
@@ -152,7 +161,6 @@ export function useKeyboardNav({ pageViewerRef, sidebarRef }: Options): void {
 
       // Escape — clear selection
       if (e.key === "Escape") {
-        e.preventDefault();
         state.clearSelection();
         return;
       }

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -427,3 +427,59 @@ describe("infoPanelOpen", () => {
     expect(useAppStore.getState().infoPanelOpen).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// selectionAnchor
+// ---------------------------------------------------------------------------
+
+describe("selectionAnchor", () => {
+  beforeEach(() => {
+    useAppStore.setState({ selectionAnchor: null, selectedPages: new Set() });
+  });
+
+  it("starts null", () => {
+    expect(useAppStore.getState().selectionAnchor).toBeNull();
+  });
+
+  it("setSelectionAnchor(3) sets anchor to 3", () => {
+    useAppStore.getState().setSelectionAnchor(3);
+    expect(useAppStore.getState().selectionAnchor).toBe(3);
+  });
+
+  it("setSelectionAnchor(null) clears the anchor", () => {
+    useAppStore.setState({ selectionAnchor: 5 });
+    useAppStore.getState().setSelectionAnchor(null);
+    expect(useAppStore.getState().selectionAnchor).toBeNull();
+  });
+
+  it("clearSelection() also resets selectionAnchor to null", () => {
+    useAppStore.setState({ selectionAnchor: 2, selectedPages: new Set([1, 2, 3]) });
+    useAppStore.getState().clearSelection();
+    expect(useAppStore.getState().selectedPages.size).toBe(0);
+    expect(useAppStore.getState().selectionAnchor).toBeNull();
+  });
+
+  it("selectionAnchor is saved and restored on tab switch", () => {
+    useAppStore.setState({
+      tabs: [],
+      activeDocId: null,
+      docViewStates: new Map(),
+      activePage: 0,
+      zoom: 75,
+      zoomMode: "manual",
+      selectedPages: new Set(),
+      isDirty: false,
+      selectionAnchor: null,
+    });
+    useAppStore.getState().addTab(MANIFEST_A);
+    useAppStore.getState().setSelectionAnchor(4);
+
+    useAppStore.getState().addTab(MANIFEST_B);
+    // anchor should reset for new doc
+    expect(useAppStore.getState().selectionAnchor).toBeNull();
+
+    // switch back to A
+    useAppStore.getState().setActiveDocId(1);
+    expect(useAppStore.getState().selectionAnchor).toBe(4);
+  });
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -13,6 +13,7 @@ export interface DocViewState {
   zoomMode: ZoomMode;
   selectedPages: ReadonlySet<number>;
   isDirty: boolean;
+  selectionAnchor: number | null;
 }
 
 export const DEFAULT_DOC_VIEW_STATE: DocViewState = {
@@ -21,6 +22,7 @@ export const DEFAULT_DOC_VIEW_STATE: DocViewState = {
   zoomMode: "manual",
   selectedPages: new Set(),
   isDirty: false,
+  selectionAnchor: null,
 };
 
 export interface TabEntry {
@@ -58,6 +60,8 @@ interface AppStore {
   selectPageRange(from: number, to: number): void;
   clearSelection(): void;
   selectAll(count: number): void;
+  selectionAnchor: number | null;
+  setSelectionAnchor: (i: number | null) => void;
 
   // Persistent preferences
   sidebarWidth: number;
@@ -84,6 +88,7 @@ function captureViewState(s: AppStore): DocViewState {
     zoomMode: s.zoomMode,
     selectedPages: s.selectedPages,
     isDirty: s.isDirty,
+    selectionAnchor: s.selectionAnchor,
   };
 }
 
@@ -215,12 +220,14 @@ export const useAppStore = create<AppStore>()(
         for (let i = lo; i <= hi; i++) next.add(i);
         set({ selectedPages: next });
       },
-      clearSelection: () => set({ selectedPages: new Set<number>() }),
+      clearSelection: () => set({ selectedPages: new Set<number>(), selectionAnchor: null }),
       selectAll: (count) => {
         const next = new Set<number>();
         for (let i = 0; i < count; i++) next.add(i);
         set({ selectedPages: next });
       },
+      selectionAnchor: null,
+      setSelectionAnchor: (i) => set({ selectionAnchor: i }),
 
       // Persistent preferences
       sidebarWidth: 160,


### PR DESCRIPTION
## Summary

- `j`/`k` now call `sidebarRef.current?.focus()` so the sidebar gains focus immediately, making Shift-selection keys (`J`, `K`, `Shift+Arrow`) work without a separate click
- `J`/`K`/`Shift+ArrowDown`/`Shift+ArrowUp` set `selectionAnchor` on the first press (when anchor is `null`), enabling repeated presses to grow the range from the original position
- `Escape` clears `selectedPages` and `selectionAnchor`
- Sidebar scroll container gets `tabIndex={-1}` + `focus:outline-none` so it is programmatically focusable without a visible ring
- Clicking a thumbnail also restores focus to the container via `containerRef.current?.focus()`

## Test plan

- [x] `make test-frontend` passes (new tests for j/k focus, J repeated-press anchor, Shift+ArrowDown repeated-press anchor, Escape clear/no-op)
- [x] Open a PDF, press `j`/`k` — sidebar gains focus without clicking
- [x] Press `J` twice from page 5 — pages 5, 6, 7 selected
- [x] Press `Escape` — selection clears
- [x] Click a thumbnail — sidebar retains focus for immediate keyboard nav