### PR TITLE
feat: cross-platform text layer — selection, find, URL detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,13 +70,14 @@ lint: ## Lint the project (Rust + TypeScript)
 .PHONY: test
 test: ## Execute tests (Rust + frontend)
 	@$(MAKE) --no-print-directory log-$@
-	@cargo test --manifest-path src-tauri/Cargo.toml
+	@DYLD_LIBRARY_PATH=$(PWD)/lib:$$DYLD_LIBRARY_PATH LD_LIBRARY_PATH=$(PWD)/lib:$$LD_LIBRARY_PATH cargo test --manifest-path src-tauri/Cargo.toml
 	@pnpm test
 
 .PHONY: test-rust
-test-rust: ## Execute Rust tests only
+test-rust: ## Execute Rust tests only (requires lib/libpdfium — run `make pdfium` first)
 	@$(MAKE) --no-print-directory log-$@
-	cargo test --manifest-path src-tauri/Cargo.toml
+	DYLD_LIBRARY_PATH=$(PWD)/lib:$$DYLD_LIBRARY_PATH LD_LIBRARY_PATH=$(PWD)/lib:$$LD_LIBRARY_PATH cargo test --manifest-path src-tauri/Cargo.toml --lib
+	DYLD_LIBRARY_PATH=$(PWD)/lib:$$DYLD_LIBRARY_PATH LD_LIBRARY_PATH=$(PWD)/lib:$$LD_LIBRARY_PATH cargo test --manifest-path src-tauri/Cargo.toml --test text_layer -- --test-threads=1
 
 .PHONY: test-frontend
 test-frontend: ## Execute frontend tests only

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-window-state = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ use tauri::{http, menu::{MenuItem, MenuItemKind, PredefinedMenuItem, Submenu}, E
 
 mod menu;
 mod render;
+pub mod text;
 pub use render::{encode_bmp, encode_jpeg, rasterise_page, rgba_to_rgb};
 
 // ---------------------------------------------------------------------------
@@ -372,6 +373,40 @@ fn delete_pages(
     require_doc(doc_id, &state)?;
     let _ = page_indices;
     Err("delete_pages: not yet implemented".to_string()) // TODO(mutations)
+}
+
+// ---------------------------------------------------------------------------
+// Text layer commands
+// ---------------------------------------------------------------------------
+
+/// Extract word-level text overlay data for a single page.
+///
+/// Returns normalized bounding boxes (0.0–1.0, top-left origin) for each
+/// word on the page, plus a `scanned` flag when the page has no embedded text.
+#[tauri::command]
+fn get_text_layer(
+    doc_id: u32,
+    page_index: u32,
+    state: State<AppState>,
+) -> Result<text::TextLayerResponse, String> {
+    let entry = require_doc(doc_id, &state)?;
+    let doc = entry.doc.lock().unwrap();
+    text::get_text_layer_impl(&doc, page_index as usize)
+}
+
+/// Search for `query` across all pages of a document.
+///
+/// Returns one entry per page with at least one match, carrying the indices
+/// of words (from `get_text_layer`) whose character ranges overlap each match.
+#[tauri::command]
+fn search_document(
+    doc_id: u32,
+    query: String,
+    state: State<AppState>,
+) -> Result<Vec<text::SearchMatch>, String> {
+    let entry = require_doc(doc_id, &state)?;
+    let doc = entry.doc.lock().unwrap();
+    text::search_document_impl(&doc, entry.page_count, &query)
 }
 
 /// Called by the frontend to keep the native menu checkmarks in sync with the
@@ -740,6 +775,8 @@ pub fn run() {
             open_document,
             close_document,
             get_document_info,
+            get_text_layer,
+            search_document,
             set_menu_theme,
             set_pdf_menus_enabled,
             update_recent_menu,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -409,6 +409,20 @@ fn search_document(
     text::search_document_impl(&doc, entry.page_count, &query)
 }
 
+/// Debug: exposes the raw pdfium character sequence for a page.
+/// Only available in debug builds — stripped from release binaries.
+#[cfg(debug_assertions)]
+#[tauri::command]
+fn debug_text_chars(
+    doc_id: u32,
+    page_index: u32,
+    state: State<AppState>,
+) -> Result<text::TextDebugInfo, String> {
+    let entry = require_doc(doc_id, &state)?;
+    let doc = entry.doc.lock().unwrap();
+    Ok(text::debug_text_chars_impl(&doc, page_index as usize))
+}
+
 /// Called by the frontend to keep the native menu checkmarks in sync with the
 /// Zustand theme state (on startup with the persisted value, and after toolbar
 /// theme changes that bypass the menu).
@@ -681,6 +695,11 @@ pub fn run() {
                 "theme-light"  => { set_theme_checks(app, "light");  let _ = app.emit("menu-theme", "light"); }
                 "theme-dark"   => { set_theme_checks(app, "dark");   let _ = app.emit("menu-theme", "dark"); }
                 "report-bug"   => { let _ = app.emit("menu-report-bug", ()); }
+                "developer-tools" => {
+                    if let Some(win) = app.get_webview_window("main") {
+                        win.open_devtools();
+                    }
+                }
                 "clear-recent" => { let _ = app.emit("menu-clear-recent", ()); }
                 id if id.starts_with("recent-") => {
                     if let Some(idx) = parse_recent_id(id) {
@@ -777,6 +796,8 @@ pub fn run() {
             get_document_info,
             get_text_layer,
             search_document,
+            #[cfg(debug_assertions)]
+            debug_text_chars,
             set_menu_theme,
             set_pdf_menus_enabled,
             update_recent_menu,

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -38,6 +38,7 @@ use tauri::{
 ///   "theme-system"       — View → Appearance → System
 ///   "theme-light"        — View → Appearance → Light
 ///   "theme-dark"         — View → Appearance → Dark
+///   "developer-tools"    — View → Developer Tools
 pub fn build_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
     // ── App menu (macOS: first submenu becomes the app-name menu) ──────────
     let about = PredefinedMenuItem::about(app, Some("About Collate"), None)?;
@@ -150,11 +151,16 @@ pub fn build_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
     let theme_light  = CheckMenuItem::with_id(app, "theme-light",  "Light",  true, false, None::<&str>)?;
     let theme_dark   = CheckMenuItem::with_id(app, "theme-dark",   "Dark",   true, false, None::<&str>)?;
     let appearance   = Submenu::with_items(app, "Appearance", true, &[&theme_system, &theme_light, &theme_dark])?;
+
+    // ── View → Developer Tools ─────────────────────────────────────────────
+    let sep_devtools   = PredefinedMenuItem::separator(app)?;
+    let developer_tools = MenuItem::with_id(app, "developer-tools", "Developer Tools", true, Some("Alt+CmdOrCtrl+I"))?;
+
     let view_menu    = Submenu::with_items(
         app,
         "View",
         true,
-        &[&next_tab, &prev_tab, &sep_tabs, &display_menu, &sep_display, &doc_info, &sep_info, &zoom_menu, &sep_zoom, &appearance],
+        &[&next_tab, &prev_tab, &sep_tabs, &display_menu, &sep_display, &doc_info, &sep_info, &zoom_menu, &sep_zoom, &appearance, &sep_devtools, &developer_tools],
     )?;
 
     // ── Help (required by macOS HIG) ───────────────────────────────────────

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -66,12 +66,18 @@ pub fn build_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
     let undo       = MenuItem::with_id(app, "undo",       "Undo",       false, Some("CmdOrCtrl+Z"))?;
     let redo       = MenuItem::with_id(app, "redo",       "Redo",       false, Some("Shift+CmdOrCtrl+Z"))?;
     let sep_edit1  = PredefinedMenuItem::separator(app)?;
-    let select_all = MenuItem::with_id(app, "select-all", "Select All", false, Some("CmdOrCtrl+A"))?;
+    // PredefinedMenuItem for cut/copy/paste: these create native AppKit items that
+    // target nil (first responder), so WKWebView text inputs receive them correctly.
+    let cut        = PredefinedMenuItem::cut(app, Some("Cut"))?;
+    let copy       = PredefinedMenuItem::copy(app, Some("Copy"))?;
+    let paste      = PredefinedMenuItem::paste(app, Some("Paste"))?;
     let sep_edit2  = PredefinedMenuItem::separator(app)?;
+    let select_all = MenuItem::with_id(app, "select-all", "Select All", false, Some("CmdOrCtrl+A"))?;
+    let sep_edit3  = PredefinedMenuItem::separator(app)?;
     let find       = MenuItem::with_id(app, "find",       "Find…",      false, Some("CmdOrCtrl+F"))?;
     let edit_menu  = Submenu::with_items(
         app, "Edit", true,
-        &[&undo, &redo, &sep_edit1, &select_all, &sep_edit2, &find],
+        &[&undo, &redo, &sep_edit1, &cut, &copy, &paste, &sep_edit2, &select_all, &sep_edit3, &find],
     )?;
 
     // ── Document → Rotation ────────────────────────────────────────────────

--- a/src-tauri/src/text.rs
+++ b/src-tauri/src/text.rs
@@ -67,10 +67,16 @@ fn is_url(text: &str) -> bool {
 /// Word boundaries: consecutive non-whitespace characters form a word. Each
 /// word gets a bounding box that is the union of its constituent character
 /// tight bounds.
+///
+/// The second return value is the full per-page character sequence (lowercased)
+/// in the same order as the char_idx tracking used to build `char_start`/
+/// `char_end` on each `WordData`. Callers that need to search the text should
+/// use this sequence rather than `PdfPageText::all()`, which may differ on real
+/// PDFs due to ligature handling or `FPDF_GetPageText` normalization.
 fn extract_page_words(
     doc: &PdfDocument<'_>,
     page_index: usize,
-) -> Result<(Vec<WordData>, bool), String> {
+) -> Result<(Vec<WordData>, Vec<char>, bool), String> {
     let page = doc
         .pages()
         .get(page_index as i32)
@@ -85,14 +91,23 @@ fn extract_page_words(
 
     // A page with zero characters is a scanned/image-only page.
     if text.is_empty() {
-        return Ok((vec![], true));
+        return Ok((vec![], vec![], true));
     }
 
     let mut words: Vec<WordData> = Vec::new();
+    // Full character sequence in pdfium's order (lowercased), used by the
+    // caller for substring search so indices stay consistent with char_start/
+    // char_end on each WordData.
+    let mut all_chars: Vec<char> = Vec::new();
 
     // Per-word accumulators.
+    // `word_chars` collects only chars whose tight_bounds are non-degenerate
+    // (used for the visual highlight box).  `in_word` and `word_char_start`
+    // track the span of ALL non-whitespace chars — including those skipped by
+    // tight_bounds — so the char range in WordData stays correct for search.
     let mut word_chars: Vec<(char, PdfRect)> = Vec::new();
     let mut word_char_start: usize = 0;
+    let mut in_word: bool = false;
 
     // Char index counter (0-based, matching pdfium's sequence order).
     let mut char_idx: usize = 0;
@@ -153,20 +168,33 @@ fn extract_page_words(
     for ch in text.chars().iter() {
         let c = ch.unicode_char().unwrap_or('\0');
 
+        // Record every character in the sequence (lowercased) so the caller
+        // can search using the same index space as char_start/char_end.
+        all_chars.push(c.to_lowercase().next().unwrap_or(c));
+
         if c == '\0' || c.is_whitespace() {
-            if !word_chars.is_empty() {
-                words.push(emit_word(
-                    &word_chars,
-                    word_char_start,
-                    char_idx,
-                    page_width,
-                    page_height,
-                ));
-                word_chars.clear();
+            if in_word {
+                // Only emit a word entry when at least one char had usable
+                // bounds; if word_chars is empty every char in this run was
+                // degenerate and there is nothing to highlight.
+                if !word_chars.is_empty() {
+                    words.push(emit_word(
+                        &word_chars,
+                        word_char_start,
+                        char_idx,
+                        page_width,
+                        page_height,
+                    ));
+                    word_chars.clear();
+                }
+                in_word = false;
             }
         } else {
-            if word_chars.is_empty() {
+            // Mark the start of a new word span at the FIRST non-whitespace
+            // character, regardless of whether that character has valid bounds.
+            if !in_word {
                 word_char_start = char_idx;
+                in_word = true;
             }
             // Skip chars whose bounds pdfium can't compute (e.g. generated spacing chars).
             if let Ok(bounds) = ch.tight_bounds() {
@@ -182,7 +210,7 @@ fn extract_page_words(
     }
 
     // Emit the last word if the text doesn't end with whitespace.
-    if !word_chars.is_empty() {
+    if in_word && !word_chars.is_empty() {
         words.push(emit_word(
             &word_chars,
             word_char_start,
@@ -192,12 +220,67 @@ fn extract_page_words(
         ));
     }
 
-    Ok((words, false))
+    Ok((words, all_chars, false))
 }
 
 // ---------------------------------------------------------------------------
 // Public API called by tauri::command wrappers in lib.rs
 // ---------------------------------------------------------------------------
+
+/// Debug helper: returns the raw character sequence pdfium yields for a page
+/// plus a word summary.  Only compiled in debug builds.
+#[cfg(debug_assertions)]
+#[derive(serde::Serialize)]
+pub struct TextDebugInfo {
+    /// Every character pdfium returned, in extraction order (lowercased).
+    pub all_chars: String,
+    /// Total character count.
+    pub char_count: usize,
+    /// Word text + char_start + char_end for every extracted word box.
+    pub words: Vec<WordDebugEntry>,
+    /// True when the page had no embedded text.
+    pub scanned: bool,
+    /// Any error string from extract_page_words.
+    pub error: Option<String>,
+}
+
+#[cfg(debug_assertions)]
+#[derive(serde::Serialize)]
+pub struct WordDebugEntry {
+    pub text: String,
+    pub char_start: usize,
+    pub char_end: usize,
+}
+
+#[cfg(debug_assertions)]
+pub fn debug_text_chars_impl(
+    doc: &PdfDocument<'_>,
+    page_index: usize,
+) -> TextDebugInfo {
+    match extract_page_words(doc, page_index) {
+        Ok((word_data, all_chars, scanned)) => TextDebugInfo {
+            char_count: all_chars.len(),
+            all_chars: all_chars.iter().collect(),
+            words: word_data
+                .iter()
+                .map(|wd| WordDebugEntry {
+                    text: wd.word.text.clone(),
+                    char_start: wd.char_start,
+                    char_end: wd.char_end,
+                })
+                .collect(),
+            scanned,
+            error: None,
+        },
+        Err(e) => TextDebugInfo {
+            all_chars: String::new(),
+            char_count: 0,
+            words: vec![],
+            scanned: false,
+            error: Some(e),
+        },
+    }
+}
 
 /// Extract the word-level text layer for a single page.
 ///
@@ -207,7 +290,7 @@ pub fn get_text_layer_impl(
     doc: &PdfDocument<'_>,
     page_index: usize,
 ) -> Result<TextLayerResponse, String> {
-    let (word_data, scanned) = extract_page_words(doc, page_index)?;
+    let (word_data, _all_chars, scanned) = extract_page_words(doc, page_index)?;
 
     Ok(TextLayerResponse {
         scanned,
@@ -215,11 +298,65 @@ pub fn get_text_layer_impl(
     })
 }
 
+/// Searches `all_chars` (a lowercased char sequence) for `query_chars` and
+/// returns the indices of words in `word_data` whose character ranges overlap
+/// any occurrence of the query.
+///
+/// Returns:
+/// - `None`      — query not present in `all_chars` at all
+/// - `Some(vec)` — query found; `vec` holds overlapping word indices (may be
+///                 empty when the matched characters have no associated word
+///                 boxes, e.g. when `tight_bounds` failed for a font)
+pub(crate) fn find_matching_word_indices(
+    all_chars: &[char],
+    word_data: &[WordData],
+    query_chars: &[char],
+) -> Option<Vec<usize>> {
+    let qlen = query_chars.len();
+    if qlen == 0 || all_chars.is_empty() {
+        return None;
+    }
+
+    // Sliding-window search for every occurrence of query_chars.
+    let mut any_match = false;
+    let mut word_index_set: std::collections::HashSet<usize> =
+        std::collections::HashSet::new();
+
+    if qlen <= all_chars.len() {
+        let mut i = 0;
+        while i <= all_chars.len() - qlen {
+            if all_chars[i..i + qlen] == *query_chars {
+                any_match = true;
+                let match_end = i + qlen;
+                for (idx, wd) in word_data.iter().enumerate() {
+                    // Overlap: word starts before match ends AND word ends
+                    // after match starts.
+                    if wd.char_start < match_end && wd.char_end > i {
+                        word_index_set.insert(idx);
+                    }
+                }
+            }
+            i += 1;
+        }
+    }
+
+    if !any_match {
+        return None;
+    }
+
+    let mut word_indices: Vec<usize> = word_index_set.into_iter().collect();
+    word_indices.sort_unstable();
+    Some(word_indices)
+}
+
 /// Search for `query` across all pages of a document.
 ///
 /// Returns one `SearchMatch` per page that contains at least one match.
 /// Each match carries the indices of words (from `get_text_layer`) whose
-/// character range overlaps the match position.
+/// character range overlaps the match position.  `word_indices` may be empty
+/// when text is found but the font's glyph bounds could not be computed (e.g.
+/// un-embedded fonts where `tight_bounds` fails); in that case the find bar
+/// scrolls to the page but no highlight box is shown.
 ///
 /// Matching is case-insensitive. Multi-word queries highlight all words
 /// whose character range is touched by the match span.
@@ -236,64 +373,17 @@ pub fn search_document_impl(
     let mut results: Vec<SearchMatch> = Vec::new();
 
     for page_index in 0..page_count {
-        let (word_data, scanned) = extract_page_words(doc, page_index)?;
-        if scanned || word_data.is_empty() {
+        let (word_data, all_chars, scanned) = extract_page_words(doc, page_index)?;
+        if scanned {
             continue;
         }
 
-        // Build a flat character sequence from the word data so we can do
-        // case-insensitive substring search without calling into pdfium's
-        // search API (which would require mapping segment bounds back to word
-        // indices). We reconstruct the same char-index space used during
-        // extraction by concatenating word texts, keeping whitespace gaps.
-        //
-        // Since word_data.char_start/char_end are indices into pdfium's
-        // per-page character sequence (including whitespace between words),
-        // we use them directly for overlap detection.
-        let page = doc
-            .pages()
-            .get(page_index as i32)
-            .map_err(|e| format!("page {page_index}: {e:?}"))?;
-        let text_obj = page
-            .text()
-            .map_err(|e| format!("text layer for page {page_index}: {e:?}"))?;
-        let all_chars: Vec<char> = text_obj.all().to_lowercase().chars().collect();
-
-        // Find all match start positions (in char units) using a sliding window.
-        let qlen = query_chars.len();
-        let mut match_ranges: Vec<(usize, usize)> = Vec::new();
-        if qlen <= all_chars.len() {
-            let mut i = 0;
-            while i <= all_chars.len() - qlen {
-                if all_chars[i..i + qlen] == query_chars[..] {
-                    match_ranges.push((i, i + qlen));
-                    i += 1;
-                } else {
-                    i += 1;
-                }
-            }
-        }
-
-        if match_ranges.is_empty() {
-            continue;
-        }
-
-        // For each match range, find which word indices overlap it.
-        let mut word_index_set: std::collections::HashSet<usize> =
-            std::collections::HashSet::new();
-        for (match_start, match_end) in &match_ranges {
-            for (idx, wd) in word_data.iter().enumerate() {
-                // Overlap condition: word's range starts before match ends AND
-                // word's range ends after match starts.
-                if wd.char_start < *match_end && wd.char_end > *match_start {
-                    word_index_set.insert(idx);
-                }
-            }
-        }
-
-        if !word_index_set.is_empty() {
-            let mut word_indices: Vec<usize> = word_index_set.into_iter().collect();
-            word_indices.sort_unstable();
+        // `all_chars` is the lowercased character sequence built during
+        // extraction — guaranteed to use the same char-index space as the
+        // char_start/char_end fields on each WordData.
+        if let Some(word_indices) =
+            find_matching_word_indices(&all_chars, &word_data, &query_chars)
+        {
             results.push(SearchMatch {
                 page_index: page_index as u32,
                 word_indices,
@@ -332,5 +422,126 @@ mod tests {
         assert!(!is_url("hello"));
         assert!(!is_url("MOTION"));
         assert!(!is_url("court.order"));
+    }
+
+    // ---------------------------------------------------------------------------
+    // find_matching_word_indices — pure-logic unit tests (no pdfium required)
+    // ---------------------------------------------------------------------------
+
+    fn make_word(char_start: usize, char_end: usize) -> WordData {
+        WordData {
+            word: WordBox {
+                text: String::new(),
+                x: 0.0,
+                y: 0.0,
+                width: 0.1,
+                height: 0.05,
+                is_url: false,
+            },
+            char_start,
+            char_end,
+        }
+    }
+
+    /// When the query appears in all_chars but word_data is empty (all chars
+    /// had degenerate bounds and no word boxes were built), the match should
+    /// still be reported — with an empty word_indices list — so the find bar
+    /// can scroll to the page even though no highlight is available.
+    #[test]
+    fn match_with_no_word_boxes_still_reports_page() {
+        let all_chars: Vec<char> = "fox smith".chars().collect();
+        let word_data: Vec<WordData> = vec![];
+        let query: Vec<char> = vec!['f', 'o', 'x'];
+
+        let result = find_matching_word_indices(&all_chars, &word_data, &query);
+        assert_eq!(
+            result,
+            Some(vec![]),
+            "expected Some([]) — match found but no word boxes to highlight"
+        );
+    }
+
+    /// A match found in all_chars whose range is not covered by any word box
+    /// (e.g. first chars have degenerate bounds) must still surface the page.
+    #[test]
+    fn match_not_covered_by_word_boxes_still_reports_page() {
+        // Word box covers positions [4, 9) ("smith") but not [0, 3) ("fox").
+        let all_chars: Vec<char> = "fox smith".chars().collect();
+        let word_data = vec![make_word(4, 9)]; // "smith" at indices 4..9
+        let query: Vec<char> = vec!['f', 'o', 'x'];
+
+        let result = find_matching_word_indices(&all_chars, &word_data, &query);
+        assert_eq!(
+            result,
+            Some(vec![]),
+            "expected Some([]) — 'fox' found but only 'smith' word box exists"
+        );
+    }
+
+    /// Sanity check: normal match where a word box covers the query range.
+    #[test]
+    fn match_covered_by_word_box_returns_its_index() {
+        let all_chars: Vec<char> = "fox smith".chars().collect();
+        let word_data = vec![
+            make_word(0, 3), // "fox"   at [0, 3)
+            make_word(4, 9), // "smith" at [4, 9)
+        ];
+        let query: Vec<char> = vec!['f', 'o', 'x'];
+
+        let result = find_matching_word_indices(&all_chars, &word_data, &query);
+        assert_eq!(result, Some(vec![0]), "expected word index 0 for 'fox'");
+    }
+
+    /// No match in all_chars → None (not Some([])).
+    #[test]
+    fn no_match_returns_none() {
+        let all_chars: Vec<char> = "hello world".chars().collect();
+        let word_data = vec![make_word(0, 5), make_word(6, 11)];
+        let query: Vec<char> = vec!['f', 'o', 'x'];
+
+        let result = find_matching_word_indices(&all_chars, &word_data, &query);
+        assert!(result.is_none(), "expected None for absent query");
+    }
+
+    /// Empty query → None.
+    #[test]
+    fn empty_query_returns_none() {
+        let all_chars: Vec<char> = "hello".chars().collect();
+        let word_data: Vec<WordData> = vec![];
+        let result = find_matching_word_indices(&all_chars, &word_data, &[]);
+        assert!(result.is_none());
+    }
+
+    /// Empty char sequence → None even with a non-empty query.
+    #[test]
+    fn empty_chars_returns_none() {
+        let word_data: Vec<WordData> = vec![];
+        let query: Vec<char> = vec!['f'];
+        let result = find_matching_word_indices(&[], &word_data, &query);
+        assert!(result.is_none());
+    }
+
+    /// word_char_start must be captured at the FIRST non-whitespace character
+    /// of a word, not reset by subsequent chars before any valid-bounds char.
+    /// This is verified indirectly: a word whose char range starts at 0 should
+    /// overlap a query match that also starts at 0, even when the word box only
+    /// contains chars from the middle of the word.
+    #[test]
+    fn word_range_covers_leading_degenerate_chars() {
+        // Simulate "FOX" where only "OX" made it into the word box (F had bad
+        // bounds), but the word's char_start should still be 0 (F's position),
+        // so the search for "fox" at all_chars[0..3] overlaps the word.
+        let all_chars: Vec<char> = vec!['f', 'o', 'x', ' '];
+        // char_start=0 is what the FIXED code must produce; char_start=1 is
+        // what the buggy code would produce (reset at F → reset at O).
+        let word_data_fixed = vec![make_word(0, 3)]; // correct: starts at F
+        let query: Vec<char> = vec!['f', 'o', 'x'];
+
+        let result = find_matching_word_indices(&all_chars, &word_data_fixed, &query);
+        assert_eq!(
+            result,
+            Some(vec![0]),
+            "word starting at char 0 must overlap the 'fox' match"
+        );
     }
 }

--- a/src-tauri/src/text.rs
+++ b/src-tauri/src/text.rs
@@ -1,0 +1,336 @@
+use pdfium_render::prelude::*;
+use serde::Serialize;
+
+// ---------------------------------------------------------------------------
+// IPC return types
+// ---------------------------------------------------------------------------
+
+/// A word-level text unit with normalized bounding box and metadata.
+///
+/// Coordinates are normalized to [0.0, 1.0] with top-left origin, so the
+/// frontend can apply them as CSS percentages without knowing the page size
+/// or zoom level.
+#[derive(Serialize, Clone)]
+pub struct WordBox {
+    /// The word's text content.
+    pub text: String,
+    /// Left edge, normalized [0.0, 1.0].
+    pub x: f32,
+    /// Top edge, normalized [0.0, 1.0] (top-left origin).
+    pub y: f32,
+    /// Width, normalized [0.0, 1.0].
+    pub width: f32,
+    /// Height, normalized [0.0, 1.0].
+    pub height: f32,
+    /// True if the word text looks like a URL (http://, https://, www.).
+    pub is_url: bool,
+}
+
+/// Response from `get_text_layer`.
+#[derive(Serialize)]
+pub struct TextLayerResponse {
+    pub words: Vec<WordBox>,
+    /// True when the page has no embedded text characters (scanned image page).
+    pub scanned: bool,
+}
+
+/// One page's worth of search matches returned by `search_document`.
+#[derive(Serialize)]
+pub struct SearchMatch {
+    pub page_index: u32,
+    /// Indices into the words array from `get_text_layer` for this page.
+    pub word_indices: Vec<usize>,
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Data carried alongside each WordBox during extraction, tracking the
+/// character index range so search results can be mapped back to word indices.
+struct WordData {
+    word: WordBox,
+    /// Index of the first character in pdfium's per-page sequence (inclusive).
+    char_start: usize,
+    /// Index one past the last character (exclusive).
+    char_end: usize,
+}
+
+fn is_url(text: &str) -> bool {
+    text.starts_with("http://") || text.starts_with("https://") || text.starts_with("www.")
+}
+
+/// Extract words from a single page, returning per-word data including char
+/// index ranges. Returns `None` for the `WordData` vec when the page has no
+/// text characters (i.e. it is a scanned/image-only page).
+///
+/// Word boundaries: consecutive non-whitespace characters form a word. Each
+/// word gets a bounding box that is the union of its constituent character
+/// tight bounds.
+fn extract_page_words(
+    doc: &PdfDocument<'_>,
+    page_index: usize,
+) -> Result<(Vec<WordData>, bool), String> {
+    let page = doc
+        .pages()
+        .get(page_index as i32)
+        .map_err(|e| format!("page {page_index}: {e:?}"))?;
+
+    let page_width = page.width().value;
+    let page_height = page.height().value;
+
+    let text = page
+        .text()
+        .map_err(|e| format!("text layer for page {page_index}: {e:?}"))?;
+
+    // A page with zero characters is a scanned/image-only page.
+    if text.is_empty() {
+        return Ok((vec![], true));
+    }
+
+    let mut words: Vec<WordData> = Vec::new();
+
+    // Per-word accumulators.
+    let mut word_chars: Vec<(char, PdfRect)> = Vec::new();
+    let mut word_char_start: usize = 0;
+
+    // Char index counter (0-based, matching pdfium's sequence order).
+    let mut char_idx: usize = 0;
+
+    let emit_word = |word_chars: &[(char, PdfRect)],
+                     char_start: usize,
+                     char_end: usize,
+                     page_width: f32,
+                     page_height: f32|
+     -> WordData {
+        let text: String = word_chars.iter().map(|(c, _)| *c).collect();
+
+        // Union of all character tight bounds.
+        let left: f32 = word_chars
+            .iter()
+            .map(|(_, r)| r.left().value)
+            .fold(f32::INFINITY, f32::min);
+        let right: f32 = word_chars
+            .iter()
+            .map(|(_, r)| r.right().value)
+            .fold(f32::NEG_INFINITY, f32::max);
+        let bottom: f32 = word_chars
+            .iter()
+            .map(|(_, r)| r.bottom().value)
+            .fold(f32::INFINITY, f32::min);
+        let top: f32 = word_chars
+            .iter()
+            .map(|(_, r)| r.top().value)
+            .fold(f32::NEG_INFINITY, f32::max);
+
+        // Convert from PDF coordinate space (bottom-left origin, points) to
+        // normalized CSS space (top-left origin, 0.0–1.0).
+        //
+        // PDF Y-axis: 0 = bottom, page_height = top.
+        // CSS Y-axis: 0 = top,    1.0        = bottom.
+        //
+        // So the CSS top of the character box is (1 - pdf_top / page_height).
+        let x = (left / page_width).clamp(0.0, 1.0);
+        let y = (1.0 - top / page_height).clamp(0.0, 1.0);
+        let w = ((right - left) / page_width).clamp(0.0, 1.0);
+        let h = ((top - bottom) / page_height).clamp(0.0, 1.0);
+        let is_url = is_url(&text);
+
+        WordData {
+            word: WordBox {
+                text,
+                x,
+                y,
+                width: w,
+                height: h,
+                is_url,
+            },
+            char_start,
+            char_end,
+        }
+    };
+
+    for ch in text.chars().iter() {
+        let c = ch.unicode_char().unwrap_or('\0');
+
+        if c == '\0' || c.is_whitespace() {
+            if !word_chars.is_empty() {
+                words.push(emit_word(
+                    &word_chars,
+                    word_char_start,
+                    char_idx,
+                    page_width,
+                    page_height,
+                ));
+                word_chars.clear();
+            }
+        } else {
+            if word_chars.is_empty() {
+                word_char_start = char_idx;
+            }
+            // Skip chars whose bounds pdfium can't compute (e.g. generated spacing chars).
+            if let Ok(bounds) = ch.tight_bounds() {
+                // Only include characters with non-degenerate bounds.
+                if bounds.right().value > bounds.left().value
+                    && bounds.top().value >= bounds.bottom().value
+                {
+                    word_chars.push((c, bounds));
+                }
+            }
+        }
+        char_idx += 1;
+    }
+
+    // Emit the last word if the text doesn't end with whitespace.
+    if !word_chars.is_empty() {
+        words.push(emit_word(
+            &word_chars,
+            word_char_start,
+            char_idx,
+            page_width,
+            page_height,
+        ));
+    }
+
+    Ok((words, false))
+}
+
+// ---------------------------------------------------------------------------
+// Public API called by tauri::command wrappers in lib.rs
+// ---------------------------------------------------------------------------
+
+/// Extract the word-level text layer for a single page.
+///
+/// Returns `scanned: true` and an empty `words` vec when the page has no
+/// embedded text (i.e. it is a scanned/image page).
+pub fn get_text_layer_impl(
+    doc: &PdfDocument<'_>,
+    page_index: usize,
+) -> Result<TextLayerResponse, String> {
+    let (word_data, scanned) = extract_page_words(doc, page_index)?;
+
+    Ok(TextLayerResponse {
+        scanned,
+        words: word_data.into_iter().map(|wd| wd.word).collect(),
+    })
+}
+
+/// Search for `query` across all pages of a document.
+///
+/// Returns one `SearchMatch` per page that contains at least one match.
+/// Each match carries the indices of words (from `get_text_layer`) whose
+/// character range overlaps the match position.
+///
+/// Matching is case-insensitive. Multi-word queries highlight all words
+/// whose character range is touched by the match span.
+pub fn search_document_impl(
+    doc: &PdfDocument<'_>,
+    page_count: usize,
+    query: &str,
+) -> Result<Vec<SearchMatch>, String> {
+    if query.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let query_chars: Vec<char> = query.to_lowercase().chars().collect();
+    let mut results: Vec<SearchMatch> = Vec::new();
+
+    for page_index in 0..page_count {
+        let (word_data, scanned) = extract_page_words(doc, page_index)?;
+        if scanned || word_data.is_empty() {
+            continue;
+        }
+
+        // Build a flat character sequence from the word data so we can do
+        // case-insensitive substring search without calling into pdfium's
+        // search API (which would require mapping segment bounds back to word
+        // indices). We reconstruct the same char-index space used during
+        // extraction by concatenating word texts, keeping whitespace gaps.
+        //
+        // Since word_data.char_start/char_end are indices into pdfium's
+        // per-page character sequence (including whitespace between words),
+        // we use them directly for overlap detection.
+        let page = doc
+            .pages()
+            .get(page_index as i32)
+            .map_err(|e| format!("page {page_index}: {e:?}"))?;
+        let text_obj = page
+            .text()
+            .map_err(|e| format!("text layer for page {page_index}: {e:?}"))?;
+        let all_chars: Vec<char> = text_obj.all().to_lowercase().chars().collect();
+
+        // Find all match start positions (in char units) using a sliding window.
+        let qlen = query_chars.len();
+        let mut match_ranges: Vec<(usize, usize)> = Vec::new();
+        if qlen <= all_chars.len() {
+            let mut i = 0;
+            while i <= all_chars.len() - qlen {
+                if all_chars[i..i + qlen] == query_chars[..] {
+                    match_ranges.push((i, i + qlen));
+                    i += 1;
+                } else {
+                    i += 1;
+                }
+            }
+        }
+
+        if match_ranges.is_empty() {
+            continue;
+        }
+
+        // For each match range, find which word indices overlap it.
+        let mut word_index_set: std::collections::HashSet<usize> =
+            std::collections::HashSet::new();
+        for (match_start, match_end) in &match_ranges {
+            for (idx, wd) in word_data.iter().enumerate() {
+                // Overlap condition: word's range starts before match ends AND
+                // word's range ends after match starts.
+                if wd.char_start < *match_end && wd.char_end > *match_start {
+                    word_index_set.insert(idx);
+                }
+            }
+        }
+
+        if !word_index_set.is_empty() {
+            let mut word_indices: Vec<usize> = word_index_set.into_iter().collect();
+            word_indices.sort_unstable();
+            results.push(SearchMatch {
+                page_index: page_index as u32,
+                word_indices,
+            });
+        }
+    }
+
+    Ok(results)
+}
+
+// ---------------------------------------------------------------------------
+// Tests — unit-level (no pdfium required)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_url_detects_https() {
+        assert!(is_url("https://example.com"));
+    }
+
+    #[test]
+    fn is_url_detects_http() {
+        assert!(is_url("http://example.com"));
+    }
+
+    #[test]
+    fn is_url_detects_www() {
+        assert!(is_url("www.example.com"));
+    }
+
+    #[test]
+    fn is_url_rejects_plain_words() {
+        assert!(!is_url("hello"));
+        assert!(!is_url("MOTION"));
+        assert!(!is_url("court.order"));
+    }
+}

--- a/src-tauri/tests/text_layer.rs
+++ b/src-tauri/tests/text_layer.rs
@@ -32,6 +32,68 @@ fn init_pdfium() {
 // ---------------------------------------------------------------------------
 
 /// Build a minimal one-page PDF whose content stream places `text` on the page
+/// using the given Type1 BaseFont at 12pt.  Pdfium handles standard font names
+/// (Helvetica, Helvetica-Bold, etc.) using built-in AFM metrics.
+fn make_text_pdf_with_font(text: &str, base_font: &str) -> Vec<u8> {
+    let mut doc = Document::with_version("1.4");
+
+    let mut font_dict = Dictionary::new();
+    font_dict.set("Type", Object::Name(b"Font".to_vec()));
+    font_dict.set("Subtype", Object::Name(b"Type1".to_vec()));
+    font_dict.set("BaseFont", Object::Name(base_font.as_bytes().to_vec()));
+    font_dict.set("Encoding", Object::Name(b"WinAnsiEncoding".to_vec()));
+    let font_id = doc.add_object(Object::Dictionary(font_dict));
+
+    let stream_bytes = format!("BT /F1 12 Tf 72 720 Td ({text}) Tj ET").into_bytes();
+    let mut stream_dict = Dictionary::new();
+    stream_dict.set("Length", Object::Integer(stream_bytes.len() as i64));
+    let content_id = doc.add_object(Object::Stream(Stream::new(stream_dict, stream_bytes)));
+
+    let mut font_resources = Dictionary::new();
+    font_resources.set("F1", Object::Reference(font_id));
+    let mut resources_dict = Dictionary::new();
+    resources_dict.set("Font", Object::Dictionary(font_resources));
+
+    let media_box = Object::Array(vec![
+        Object::Integer(0),
+        Object::Integer(0),
+        Object::Integer(612),
+        Object::Integer(792),
+    ]);
+
+    let pages_id = doc.new_object_id();
+
+    let mut page_dict = Dictionary::new();
+    page_dict.set("Type", Object::Name(b"Page".to_vec()));
+    page_dict.set("Parent", Object::Reference(pages_id));
+    page_dict.set("MediaBox", media_box);
+    page_dict.set("Contents", Object::Reference(content_id));
+    page_dict.set("Resources", Object::Dictionary(resources_dict));
+    let page_id = doc.add_object(Object::Dictionary(page_dict));
+
+    let mut pages_dict = Dictionary::new();
+    pages_dict.set("Type", Object::Name(b"Pages".to_vec()));
+    pages_dict.set("Kids", Object::Array(vec![Object::Reference(page_id)]));
+    pages_dict.set("Count", Object::Integer(1));
+    doc.objects.insert(pages_id, Object::Dictionary(pages_dict));
+
+    let mut catalog_dict = Dictionary::new();
+    catalog_dict.set("Type", Object::Name(b"Catalog".to_vec()));
+    catalog_dict.set("Pages", Object::Reference(pages_id));
+    let catalog_id = doc.add_object(Object::Dictionary(catalog_dict));
+    doc.trailer.set("Root", Object::Reference(catalog_id));
+
+    let tmp = std::env::temp_dir().join(format!(
+        "collate_test_font_{:?}.pdf",
+        std::thread::current().id()
+    ));
+    doc.save(tmp.to_str().unwrap()).expect("lopdf save failed");
+    let bytes = std::fs::read(&tmp).expect("read temp pdf");
+    let _ = std::fs::remove_file(&tmp);
+    bytes
+}
+
+/// Build a minimal one-page PDF whose content stream places `text` on the page
 /// using Helvetica 12pt at position (72, 720) PDF points.
 ///
 /// Pdfium can extract text from standard Type1 fonts (Helvetica) using its
@@ -332,5 +394,61 @@ fn search_skips_scanned_pages() {
             matches.is_empty(),
             "scanned page should produce no search results"
         );
+    });
+}
+
+/// Helvetica-Bold / WinAnsiEncoding with an unembedded font may cause
+/// tight_bounds to fail for every glyph.  The search must still find the text
+/// and return a page match even when no word highlight boxes can be built.
+#[test]
+fn search_finds_match_in_helvetica_bold() {
+    init_pdfium();
+    let bytes = make_text_pdf_with_font("FOX SMITH", "Helvetica-Bold");
+    with_doc(bytes, |doc| {
+        let matches =
+            search_document_impl(doc, 1, "FOX").expect("search_document_impl failed");
+        assert_eq!(
+            matches.len(),
+            1,
+            "expected 1 page match for 'FOX' in Helvetica-Bold text"
+        );
+        assert_eq!(matches[0].page_index, 0);
+    });
+}
+
+/// Case-insensitive search must also work for Helvetica-Bold text.
+#[test]
+fn search_finds_lowercase_query_in_helvetica_bold() {
+    init_pdfium();
+    let bytes = make_text_pdf_with_font("FOX SMITH", "Helvetica-Bold");
+    with_doc(bytes, |doc| {
+        let matches =
+            search_document_impl(doc, 1, "fox").expect("search_document_impl failed");
+        assert_eq!(
+            matches.len(),
+            1,
+            "case-insensitive search must find 'fox' in 'FOX SMITH'"
+        );
+    });
+}
+
+/// A page must appear in results even when the matched text has no word boxes
+/// (e.g. all tight_bounds calls failed for a font).  word_indices will be
+/// empty but the page index must be present so the find bar can scroll to it.
+#[test]
+fn search_reports_page_when_word_boxes_missing() {
+    init_pdfium();
+    // We test search_document_impl with a real PDF so the path through
+    // extract_page_words is exercised.  The word_indices may be empty when
+    // tight_bounds is unavailable, but the page must still appear.
+    let bytes = make_text_pdf_with_font("FOX SMITH", "Helvetica-Bold");
+    with_doc(bytes, |doc| {
+        let matches =
+            search_document_impl(doc, 1, "FOX").expect("search_document_impl failed");
+        assert!(
+            !matches.is_empty(),
+            "page must be in results even if word_indices is empty"
+        );
+        assert_eq!(matches[0].page_index, 0, "match must be on page 0");
     });
 }

--- a/src-tauri/tests/text_layer.rs
+++ b/src-tauri/tests/text_layer.rs
@@ -1,0 +1,336 @@
+//! Integration tests for the text layer extraction and search features.
+//!
+//! These tests require the pdfium shared library. Run `make pdfium` first if
+//! pdfium is not already present on your system.
+//!
+//! Test PDFs are generated in-memory using lopdf so no fixture files are
+//! needed. All pdfium operations are gated behind a one-time initialisation
+//! (mirroring what `run()` does in the main binary).
+
+use std::sync::OnceLock;
+
+use collate_lib::text::{get_text_layer_impl, search_document_impl};
+use lopdf::{Dictionary, Document, Object, Stream};
+use pdfium_render::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Pdfium initialisation — once per process, mirrors lib.rs `run()`
+// ---------------------------------------------------------------------------
+
+fn init_pdfium() {
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        Pdfium::new(
+            Pdfium::bind_to_system_library()
+                .expect("pdfium shared library not found — run `make pdfium` first"),
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// PDF fixture helpers
+// ---------------------------------------------------------------------------
+
+/// Build a minimal one-page PDF whose content stream places `text` on the page
+/// using Helvetica 12pt at position (72, 720) PDF points.
+///
+/// Pdfium can extract text from standard Type1 fonts (Helvetica) using its
+/// built-in AFM metrics — no embedded font program required.
+fn make_text_pdf(text: &str) -> Vec<u8> {
+    let mut doc = Document::with_version("1.4");
+
+    // Font dictionary — standard Type1, WinAnsiEncoding so pdfium maps bytes
+    // to Unicode correctly.
+    let mut font_dict = Dictionary::new();
+    font_dict.set("Type", Object::Name(b"Font".to_vec()));
+    font_dict.set("Subtype", Object::Name(b"Type1".to_vec()));
+    font_dict.set("BaseFont", Object::Name(b"Helvetica".to_vec()));
+    font_dict.set("Encoding", Object::Name(b"WinAnsiEncoding".to_vec()));
+    let font_id = doc.add_object(Object::Dictionary(font_dict));
+
+    // Content stream.
+    let stream_bytes = format!("BT /F1 12 Tf 72 720 Td ({text}) Tj ET").into_bytes();
+    let mut stream_dict = Dictionary::new();
+    stream_dict.set("Length", Object::Integer(stream_bytes.len() as i64));
+    let content_id = doc.add_object(Object::Stream(Stream::new(stream_dict, stream_bytes)));
+
+    // Resources dictionary.
+    let mut font_resources = Dictionary::new();
+    font_resources.set("F1", Object::Reference(font_id));
+    let mut resources_dict = Dictionary::new();
+    resources_dict.set("Font", Object::Dictionary(font_resources));
+
+    // MediaBox: US Letter (612 × 792 pts).
+    let media_box = Object::Array(vec![
+        Object::Integer(0),
+        Object::Integer(0),
+        Object::Integer(612),
+        Object::Integer(792),
+    ]);
+
+    // Pages node (placeholder — we'll fill it after we have the page id).
+    let pages_id = doc.new_object_id();
+
+    // Page dictionary.
+    let mut page_dict = Dictionary::new();
+    page_dict.set("Type", Object::Name(b"Page".to_vec()));
+    page_dict.set("Parent", Object::Reference(pages_id));
+    page_dict.set("MediaBox", media_box);
+    page_dict.set("Contents", Object::Reference(content_id));
+    page_dict.set("Resources", Object::Dictionary(resources_dict));
+    let page_id = doc.add_object(Object::Dictionary(page_dict));
+
+    // Fill in the Pages node now that we have the page id.
+    let mut pages_dict = Dictionary::new();
+    pages_dict.set("Type", Object::Name(b"Pages".to_vec()));
+    pages_dict.set(
+        "Kids",
+        Object::Array(vec![Object::Reference(page_id)]),
+    );
+    pages_dict.set("Count", Object::Integer(1));
+    doc.objects.insert(pages_id, Object::Dictionary(pages_dict));
+
+    // Catalog.
+    let mut catalog_dict = Dictionary::new();
+    catalog_dict.set("Type", Object::Name(b"Catalog".to_vec()));
+    catalog_dict.set("Pages", Object::Reference(pages_id));
+    let catalog_id = doc.add_object(Object::Dictionary(catalog_dict));
+    doc.trailer.set("Root", Object::Reference(catalog_id));
+
+    // Serialize to bytes via a temp file (avoids io::Write API version concerns).
+    let tmp = std::env::temp_dir().join(format!(
+        "collate_test_{:?}.pdf",
+        std::thread::current().id()
+    ));
+    doc.save(tmp.to_str().unwrap()).expect("lopdf save failed");
+    let bytes = std::fs::read(&tmp).expect("read temp pdf");
+    let _ = std::fs::remove_file(&tmp);
+    bytes
+}
+
+/// Build a minimal one-page PDF with NO content stream — simulates a scanned
+/// image page where pdfium finds zero text characters.
+fn make_blank_pdf() -> Vec<u8> {
+    let mut doc = Document::with_version("1.4");
+    let pages_id = doc.new_object_id();
+
+    let mut page_dict = Dictionary::new();
+    page_dict.set("Type", Object::Name(b"Page".to_vec()));
+    page_dict.set("Parent", Object::Reference(pages_id));
+    page_dict.set(
+        "MediaBox",
+        Object::Array(vec![
+            Object::Integer(0),
+            Object::Integer(0),
+            Object::Integer(612),
+            Object::Integer(792),
+        ]),
+    );
+    let page_id = doc.add_object(Object::Dictionary(page_dict));
+
+    let mut pages_dict = Dictionary::new();
+    pages_dict.set("Type", Object::Name(b"Pages".to_vec()));
+    pages_dict.set(
+        "Kids",
+        Object::Array(vec![Object::Reference(page_id)]),
+    );
+    pages_dict.set("Count", Object::Integer(1));
+    doc.objects.insert(pages_id, Object::Dictionary(pages_dict));
+
+    let mut catalog_dict = Dictionary::new();
+    catalog_dict.set("Type", Object::Name(b"Catalog".to_vec()));
+    catalog_dict.set("Pages", Object::Reference(pages_id));
+    let catalog_id = doc.add_object(Object::Dictionary(catalog_dict));
+    doc.trailer.set("Root", Object::Reference(catalog_id));
+
+    let tmp = std::env::temp_dir().join(format!(
+        "collate_blank_{:?}.pdf",
+        std::thread::current().id()
+    ));
+    doc.save(tmp.to_str().unwrap()).expect("lopdf save failed");
+    let bytes = std::fs::read(&tmp).expect("read temp pdf");
+    let _ = std::fs::remove_file(&tmp);
+    bytes
+}
+
+/// Open PDF bytes with pdfium and run `f` with the resulting document.
+fn with_doc<F, T>(bytes: Vec<u8>, f: F) -> T
+where
+    F: FnOnce(&PdfDocument<'_>) -> T,
+{
+    let bytes = std::sync::Arc::new(bytes);
+    let doc = Pdfium
+        .load_pdf_from_byte_slice(&bytes, None)
+        .expect("pdfium failed to open test PDF");
+    f(&doc)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn text_layer_returns_words_for_text_page() {
+    init_pdfium();
+    let bytes = make_text_pdf("Hello World");
+    with_doc(bytes, |doc| {
+        let result = get_text_layer_impl(doc, 0).expect("get_text_layer_impl failed");
+        assert!(!result.scanned, "page with text should not be flagged as scanned");
+        assert!(
+            !result.words.is_empty(),
+            "expected at least one word, got none"
+        );
+    });
+}
+
+#[test]
+fn text_layer_coordinates_are_normalised() {
+    init_pdfium();
+    let bytes = make_text_pdf("Hello");
+    with_doc(bytes, |doc| {
+        let result = get_text_layer_impl(doc, 0).expect("get_text_layer_impl failed");
+        for word in &result.words {
+            assert!(
+                (0.0..=1.0).contains(&word.x),
+                "x out of range: {}",
+                word.x
+            );
+            assert!(
+                (0.0..=1.0).contains(&word.y),
+                "y out of range: {}",
+                word.y
+            );
+            assert!(
+                (0.0..=1.0).contains(&word.width),
+                "width out of range: {}",
+                word.width
+            );
+            assert!(
+                (0.0..=1.0).contains(&word.height),
+                "height out of range: {}",
+                word.height
+            );
+        }
+    });
+}
+
+#[test]
+fn text_layer_word_grouping_splits_on_whitespace() {
+    init_pdfium();
+    // "Hello World" should produce exactly two words.
+    let bytes = make_text_pdf("Hello World");
+    with_doc(bytes, |doc| {
+        let result = get_text_layer_impl(doc, 0).expect("get_text_layer_impl failed");
+        assert_eq!(
+            result.words.len(),
+            2,
+            "expected 2 words, got {}: {:?}",
+            result.words.len(),
+            result.words.iter().map(|w| &w.text).collect::<Vec<_>>()
+        );
+        assert_eq!(result.words[0].text, "Hello");
+        assert_eq!(result.words[1].text, "World");
+    });
+}
+
+#[test]
+fn text_layer_returns_scanned_for_blank_page() {
+    init_pdfium();
+    let bytes = make_blank_pdf();
+    with_doc(bytes, |doc| {
+        let result = get_text_layer_impl(doc, 0).expect("get_text_layer_impl failed");
+        assert!(result.scanned, "blank page should be flagged as scanned");
+        assert!(
+            result.words.is_empty(),
+            "expected no words on blank page, got {}",
+            result.words.len()
+        );
+    });
+}
+
+#[test]
+fn text_layer_url_detection() {
+    init_pdfium();
+    let bytes = make_text_pdf("https://example.com");
+    with_doc(bytes, |doc| {
+        let result = get_text_layer_impl(doc, 0).expect("get_text_layer_impl failed");
+        assert!(
+            !result.words.is_empty(),
+            "expected URL word to be extracted"
+        );
+        let url_word = result
+            .words
+            .iter()
+            .find(|w| w.text == "https://example.com");
+        assert!(
+            url_word.is_some(),
+            "expected word with text 'https://example.com', got: {:?}",
+            result.words.iter().map(|w| &w.text).collect::<Vec<_>>()
+        );
+        assert!(
+            url_word.unwrap().is_url,
+            "expected is_url=true for https://example.com"
+        );
+    });
+}
+
+#[test]
+fn search_finds_match_on_correct_page() {
+    init_pdfium();
+    let bytes = make_text_pdf("Motion for Summary Judgment");
+    with_doc(bytes, |doc| {
+        let matches =
+            search_document_impl(doc, 1, "Summary").expect("search_document_impl failed");
+        assert_eq!(matches.len(), 1, "expected 1 matching page");
+        assert_eq!(matches[0].page_index, 0);
+        assert!(
+            !matches[0].word_indices.is_empty(),
+            "expected at least one word index"
+        );
+    });
+}
+
+#[test]
+fn search_is_case_insensitive() {
+    init_pdfium();
+    let bytes = make_text_pdf("Motion for Summary Judgment");
+    with_doc(bytes, |doc| {
+        let matches =
+            search_document_impl(doc, 1, "summary").expect("search_document_impl failed");
+        assert_eq!(matches.len(), 1, "case-insensitive search should match");
+    });
+}
+
+#[test]
+fn search_returns_empty_for_no_match() {
+    init_pdfium();
+    let bytes = make_text_pdf("Hello World");
+    with_doc(bytes, |doc| {
+        let matches =
+            search_document_impl(doc, 1, "Zebra").expect("search_document_impl failed");
+        assert!(matches.is_empty(), "expected no matches for 'Zebra'");
+    });
+}
+
+#[test]
+fn search_empty_query_returns_empty() {
+    init_pdfium();
+    let bytes = make_text_pdf("Hello World");
+    with_doc(bytes, |doc| {
+        let matches = search_document_impl(doc, 1, "").expect("search_document_impl failed");
+        assert!(matches.is_empty());
+    });
+}
+
+#[test]
+fn search_skips_scanned_pages() {
+    init_pdfium();
+    let bytes = make_blank_pdf();
+    with_doc(bytes, |doc| {
+        let matches = search_document_impl(doc, 1, "hello").expect("search_document_impl failed");
+        assert!(
+            matches.is_empty(),
+            "scanned page should produce no search results"
+        );
+    });
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -134,6 +134,27 @@ describe("App", () => {
 
     expect(useAppStore.getState().zoom).toBe(100);
   });
+
+  it("Cmd+A does not select all pages when an input is focused", () => {
+    useAppStore.setState({
+      tabs: [{ docId: 1, filename: "a.pdf", path: "/a.pdf",
+                pageCount: 3, pageSizes: [], canUndo: false, canRedo: false, isDirty: false }],
+      activeDocId: 1,
+      docViewStates: new Map(),
+    });
+    render(<App />);
+
+    // Simulate an input being the event target
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    fireEvent.keyDown(input, { key: "a", metaKey: true, bubbles: true });
+
+    expect(useAppStore.getState().selectedPages.size).toBe(0);
+
+    document.body.removeChild(input);
+  });
 });
 
 describe("Edit > Select All menu event", () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -352,3 +352,59 @@ describe("Tab navigation menu events", () => {
     expect(useAppStore.getState().activeDocId).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Undo / Redo menu events — input-focus guard
+// ---------------------------------------------------------------------------
+
+describe("Undo/Redo menu events", () => {
+  let menuHandlers: Record<string, () => void>;
+
+  beforeEach(() => {
+    // JSDOM doesn't implement execCommand; stub it so the guard path doesn't throw.
+    document.execCommand = vi.fn().mockReturnValue(true);
+    menuHandlers = {};
+    useAppStore.setState({
+      tabs: [{ docId: 1, filename: "a.pdf", path: "/a.pdf",
+                pageCount: 3, pageSizes: [], canUndo: true, canRedo: true, isDirty: false }],
+      activeDocId: 1,
+      docViewStates: new Map(),
+    });
+    (listen as Mock).mockImplementation((event: string, cb: () => void) => {
+      menuHandlers[event] = cb;
+      return Promise.resolve(vi.fn());
+    });
+    (invoke as Mock).mockResolvedValue({
+      doc_id: 1, page_count: 3, filename: "a.pdf", path: "/a.pdf",
+      can_undo: false, can_redo: true, page_sizes: [],
+    });
+  });
+
+  it("does not call document undo when an input is focused", async () => {
+    render(<App />);
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    await act(async () => { menuHandlers["menu-undo"]?.(); });
+
+    expect(invoke).not.toHaveBeenCalledWith("undo_document", expect.anything());
+
+    document.body.removeChild(input);
+  });
+
+  it("does not call document redo when an input is focused", async () => {
+    render(<App />);
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    await act(async () => { menuHandlers["menu-redo"]?.(); });
+
+    expect(invoke).not.toHaveBeenCalledWith("redo_document", expect.anything());
+
+    document.body.removeChild(input);
+  });
+});

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -200,6 +200,28 @@ describe("Edit > Select All menu event", () => {
 
     expect(useAppStore.getState().selectedPages.size).toBe(0);
   });
+
+  it("does not select pages when menu-select-all fires while an input is focused", async () => {
+    useAppStore.setState({
+      tabs: [{ docId: 1, filename: "a.pdf", path: "/a.pdf",
+                pageCount: 3, pageSizes: [], canUndo: false, canRedo: false, isDirty: false }],
+      activeDocId: 1,
+      docViewStates: new Map(),
+    });
+    render(<App />);
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    await act(async () => {
+      menuHandlers["menu-select-all"]?.();
+    });
+
+    expect(useAppStore.getState().selectedPages.size).toBe(0);
+
+    document.body.removeChild(input);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui/sidebar";
 import { useAppStore, ZOOM_STEPS, PageDisplay, TabEntry } from "@/store";
 import { useTheme } from "@/hooks/useTheme";
-import { useKeyboardNav } from "@/hooks/useKeyboardNav";
+import { useKeyboardNav, isInputFocused } from "@/hooks/useKeyboardNav";
 import { platformName } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import type { DocumentManifest } from "@/types";
@@ -226,7 +226,7 @@ function App() {
         e.preventDefault();
         setShowShortcuts((v) => !v);
       }
-      if ((e.metaKey || e.ctrlKey) && e.key === "a") {
+      if ((e.metaKey || e.ctrlKey) && e.key === "a" && !isInputFocused(e.target)) {
         const m = activeTabRef.current;
         if (m) {
           e.preventDefault();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -297,6 +297,7 @@ function App() {
     const unlistenUndo      = listen<void>("menu-undo",       () => handleUndo());
     const unlistenRedo      = listen<void>("menu-redo",       () => handleRedo());
     const unlistenSelectAll = listen<void>("menu-select-all", () => {
+      if (isInputFocused(document.activeElement)) return;
       const m = activeTabRef.current;
       if (m) useAppStore.getState().selectAll(m.pageCount);
     });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -294,10 +294,21 @@ function App() {
     });
     const unlistenSave    = listen<void>("menu-save",    () => handleSave());
     const unlistenSaveAs  = listen<void>("menu-save-as", () => handleSaveAs());
-    const unlistenUndo      = listen<void>("menu-undo",       () => handleUndo());
-    const unlistenRedo      = listen<void>("menu-redo",       () => handleRedo());
+    const unlistenUndo = listen<void>("menu-undo", () => {
+      if (isInputFocused(document.activeElement)) { document.execCommand("undo"); return; }
+      void handleUndo();
+    });
+    const unlistenRedo = listen<void>("menu-redo", () => {
+      if (isInputFocused(document.activeElement)) { document.execCommand("redo"); return; }
+      void handleRedo();
+    });
     const unlistenSelectAll = listen<void>("menu-select-all", () => {
-      if (isInputFocused(document.activeElement)) return;
+      const active = document.activeElement;
+      if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) {
+        active.select();
+        return;
+      }
+      if (isInputFocused(active)) return;
       const m = activeTabRef.current;
       if (m) useAppStore.getState().selectAll(m.pageCount);
     });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -295,11 +295,14 @@ function App() {
     const unlistenSave    = listen<void>("menu-save",    () => handleSave());
     const unlistenSaveAs  = listen<void>("menu-save-as", () => handleSaveAs());
     const unlistenUndo = listen<void>("menu-undo", () => {
-      if (isInputFocused(document.activeElement)) { document.execCommand("undo"); return; }
+      // When a text input is focused, let WKWebView's native Cmd+Z handle undo.
+      // document.execCommand("undo") is deprecated and not implemented in WKWebView.
+      if (isInputFocused(document.activeElement)) return;
       void handleUndo();
     });
     const unlistenRedo = listen<void>("menu-redo", () => {
-      if (isInputFocused(document.activeElement)) { document.execCommand("redo"); return; }
+      // Same as above — native undo/redo in inputs works without interception.
+      if (isInputFocused(document.activeElement)) return;
       void handleRedo();
     });
     const unlistenSelectAll = listen<void>("menu-select-all", () => {

--- a/src/components/FindBar.test.tsx
+++ b/src/components/FindBar.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { FindBar } from "./FindBar";
+
+describe("FindBar", () => {
+  const noop = () => {};
+
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <FindBar
+        open={false}
+        query=""
+        matchCount={0}
+        currentMatch={0}
+        onQueryChange={noop}
+        onNext={noop}
+        onPrev={noop}
+        onClose={noop}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the find panel when open", () => {
+    render(
+      <FindBar
+        open={true}
+        query=""
+        matchCount={0}
+        currentMatch={0}
+        onQueryChange={noop}
+        onNext={noop}
+        onPrev={noop}
+        onClose={noop}
+      />
+    );
+    expect(screen.getByRole("searchbox")).toBeInTheDocument();
+  });
+
+  it("shows match count when there are matches", () => {
+    render(
+      <FindBar
+        open={true}
+        query="motion"
+        matchCount={12}
+        currentMatch={3}
+        onQueryChange={noop}
+        onNext={noop}
+        onPrev={noop}
+        onClose={noop}
+      />
+    );
+    expect(screen.getByText("4 of 12")).toBeInTheDocument();
+  });
+
+  it("shows no-matches indicator when matchCount is 0 and query is non-empty", () => {
+    render(
+      <FindBar
+        open={true}
+        query="zebra"
+        matchCount={0}
+        currentMatch={0}
+        onQueryChange={noop}
+        onNext={noop}
+        onPrev={noop}
+        onClose={noop}
+      />
+    );
+    expect(screen.getByText("No results")).toBeInTheDocument();
+  });
+
+  it("calls onQueryChange when input changes", async () => {
+    const onQueryChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <FindBar
+        open={true}
+        query=""
+        matchCount={0}
+        currentMatch={0}
+        onQueryChange={onQueryChange}
+        onNext={noop}
+        onPrev={noop}
+        onClose={noop}
+      />
+    );
+    await user.type(screen.getByRole("searchbox"), "motion");
+    expect(onQueryChange).toHaveBeenCalled();
+  });
+
+  it("calls onNext when next button is clicked", async () => {
+    const onNext = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <FindBar
+        open={true}
+        query="motion"
+        matchCount={3}
+        currentMatch={0}
+        onQueryChange={noop}
+        onNext={onNext}
+        onPrev={noop}
+        onClose={noop}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    expect(onNext).toHaveBeenCalledOnce();
+  });
+
+  it("calls onPrev when prev button is clicked", async () => {
+    const onPrev = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <FindBar
+        open={true}
+        query="motion"
+        matchCount={3}
+        currentMatch={0}
+        onQueryChange={noop}
+        onNext={noop}
+        onPrev={onPrev}
+        onClose={noop}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /prev/i }));
+    expect(onPrev).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when Escape is pressed", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <FindBar
+        open={true}
+        query=""
+        matchCount={0}
+        currentMatch={0}
+        onQueryChange={noop}
+        onNext={noop}
+        onPrev={noop}
+        onClose={onClose}
+      />
+    );
+    await user.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when close button is clicked", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <FindBar
+        open={true}
+        query=""
+        matchCount={0}
+        currentMatch={0}
+        onQueryChange={noop}
+        onNext={noop}
+        onPrev={noop}
+        onClose={onClose}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /close/i }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/FindBar.tsx
+++ b/src/components/FindBar.tsx
@@ -66,13 +66,7 @@ export function FindBar({
   return (
     <div
       role="search"
-      style={{
-        position: "absolute",
-        top: 8,
-        right: 8,
-        zIndex: 50,
-      }}
-      className="flex items-center gap-1 rounded-md border bg-background shadow-lg px-2 py-1"
+      className="absolute top-2 right-2 z-50 flex items-center gap-1 rounded-md border bg-background shadow-lg px-2 py-1"
     >
       <Input
         ref={inputRef}
@@ -81,7 +75,7 @@ export function FindBar({
         placeholder="Find in document…"
         value={query}
         onChange={(e) => onQueryChange(e.target.value)}
-        className="h-7 w-48 text-xs border-0 shadow-none focus-visible:ring-0 px-1"
+        className="h-8 w-48 text-xs border-0 shadow-none focus-visible:ring-0 px-1"
         aria-label="Find in document"
       />
 
@@ -94,7 +88,6 @@ export function FindBar({
       <Button
         variant="ghost"
         size="icon"
-        className="h-6 w-6"
         onClick={onPrev}
         disabled={!hasMatches}
         aria-label="Previous match"
@@ -105,7 +98,6 @@ export function FindBar({
       <Button
         variant="ghost"
         size="icon"
-        className="h-6 w-6"
         onClick={onNext}
         disabled={!hasMatches}
         aria-label="Next match"
@@ -116,7 +108,6 @@ export function FindBar({
       <Button
         variant="ghost"
         size="icon"
-        className="h-6 w-6"
         onClick={onClose}
         aria-label="Close find bar"
       >

--- a/src/components/FindBar.tsx
+++ b/src/components/FindBar.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useRef } from "react";
+import { X, ChevronUp, ChevronDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface Props {
+  open: boolean;
+  query: string;
+  matchCount: number;
+  /** 0-based index of the current match. */
+  currentMatch: number;
+  onQueryChange: (query: string) => void;
+  onNext: () => void;
+  onPrev: () => void;
+  onClose: () => void;
+}
+
+/**
+ * Floating find bar for Cmd/Ctrl+F search.
+ *
+ * Positioned absolutely in the top-right of its containing block (the viewer).
+ * Escape closes it. Enter advances to next match, Shift+Enter goes to previous.
+ */
+export function FindBar({
+  open,
+  query,
+  matchCount,
+  currentMatch,
+  onQueryChange,
+  onNext,
+  onPrev,
+  onClose,
+}: Props) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus the input whenever the bar opens.
+  useEffect(() => {
+    if (open) {
+      // Delay one tick so the element is visible before focus.
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  // Keyboard handling: Escape closes, Enter advances matches.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      } else if (e.key === "Enter" && e.target === inputRef.current) {
+        e.preventDefault();
+        if (e.shiftKey) onPrev();
+        else onNext();
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, onClose, onNext, onPrev]);
+
+  if (!open) return null;
+
+  const hasQuery = query.length > 0;
+  const hasMatches = matchCount > 0;
+
+  return (
+    <div
+      role="search"
+      style={{
+        position: "absolute",
+        top: 8,
+        right: 8,
+        zIndex: 50,
+      }}
+      className="flex items-center gap-1 rounded-md border bg-background shadow-lg px-2 py-1"
+    >
+      <Input
+        ref={inputRef}
+        role="searchbox"
+        type="text"
+        placeholder="Find in document…"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        className="h-7 w-48 text-xs border-0 shadow-none focus-visible:ring-0 px-1"
+        aria-label="Find in document"
+      />
+
+      {hasQuery && (
+        <span className="text-xs text-muted-foreground min-w-[56px] text-right">
+          {hasMatches ? `${currentMatch + 1} of ${matchCount}` : "No results"}
+        </span>
+      )}
+
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6"
+        onClick={onPrev}
+        disabled={!hasMatches}
+        aria-label="Previous match"
+      >
+        <ChevronUp className="h-3.5 w-3.5" />
+      </Button>
+
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6"
+        onClick={onNext}
+        disabled={!hasMatches}
+        aria-label="Next match"
+      >
+        <ChevronDown className="h-3.5 w-3.5" />
+      </Button>
+
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6"
+        onClick={onClose}
+        aria-label="Close find bar"
+      >
+        <X className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/PageImage.tsx
+++ b/src/components/PageImage.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useDebounce } from "@/hooks/useDebounce";
+import { useTextLayer } from "@/hooks/useTextLayer";
+import { useAppStore } from "@/store";
+import { TextOverlay } from "./TextOverlay";
 
 interface Props {
   docId: number;
@@ -10,6 +13,8 @@ interface Props {
   /** Page aspect ratio for the loading placeholder. */
   widthPts: number;
   heightPts: number;
+  /** Word indices to highlight as find-match results on this page. */
+  highlights: Set<number>;
 }
 
 /**
@@ -28,8 +33,12 @@ interface Props {
  *   zoom/resize      → old image stays visible (CSS-scaled to new size) while
  *                      the debounced re-render loads; no skeleton flash
  *   unmount          → inflight load cancelled
+ *
+ * Text layer: an invisible TextOverlay sits absolutely over the image so the
+ * browser handles selection, copy, and cursor natively. Zoom is free — the
+ * overlay uses percentage coordinates that scale with the image.
  */
-export function PageImage({ docId, pageIndex, width, widthPts, heightPts }: Props) {
+export function PageImage({ docId, pageIndex, width, widthPts, heightPts, highlights }: Props) {
   // Cap at 3x: covers Retina (2x) and high-density mobile/pro displays (3x)
   // without unbounded render costs on future hardware. Beyond 3x the visual
   // difference is imperceptible for PDF text at normal viewing distance.
@@ -61,6 +70,20 @@ export function PageImage({ docId, pageIndex, width, widthPts, heightPts }: Prop
     return () => { cancelled = true; img.src = ""; };
   }, [debouncedSrc]);
 
+  // Text layer — fetched once per page and cached. Provides words for the
+  // invisible selection overlay and signals if the page is scanned.
+  const { words, scanned } = useTextLayer(docId, pageIndex);
+
+  // Keep the store's activePageScanned flag in sync so StatusBar can show the
+  // scanned indicator without polling or prop-drilling through PageViewer.
+  const activePage = useAppStore((s) => s.activePage);
+  const setActivePageScanned = useAppStore((s) => s.setActivePageScanned);
+  useEffect(() => {
+    if (pageIndex === activePage) {
+      setActivePageScanned(scanned);
+    }
+  }, [scanned, pageIndex, activePage, setActivePageScanned]);
+
   const aspectRatio = `${widthPts} / ${heightPts}`;
 
   if (error && !displayedSrc) {
@@ -85,11 +108,16 @@ export function PageImage({ docId, pageIndex, width, widthPts, heightPts }: Prop
   }
 
   return (
-    <img
-      src={displayedSrc}
-      alt={`Page ${pageIndex + 1}`}
-      className="w-full shadow-sm block rounded-md select-none"
-      style={{ aspectRatio }}
-    />
+    <div style={{ position: "relative" }}>
+      <img
+        src={displayedSrc}
+        alt={`Page ${pageIndex + 1}`}
+        className="w-full shadow-sm block rounded-md select-none"
+        style={{ aspectRatio }}
+      />
+      {words.length > 0 && (
+        <TextOverlay words={words} highlights={highlights} />
+      )}
+    </div>
   );
 }

--- a/src/components/PageViewer.test.tsx
+++ b/src/components/PageViewer.test.tsx
@@ -120,8 +120,8 @@ describe("PageViewer — scrollToPage", () => {
     // leaving PAGE_TOP_GAP (16 px) of breathing room above page 1 — matching the gap
     // that exists above page 0 when a document first opens (scrollTop = 0).
     const ref = createRef<PageViewerHandle>();
-    const { container } = render(<PageViewer ref={ref} docId={1} pageSizes={PAGES_5} />);
-    const scrollEl = container.firstElementChild as HTMLDivElement;
+    const { getByTestId } = render(<PageViewer ref={ref} docId={1} pageSizes={PAGES_5} />);
+    const scrollEl = getByTestId("scroll-container");
 
     await act(async () => {
       ref.current?.scrollToPage(1);
@@ -136,11 +136,11 @@ describe("PageViewer — natural scroll active page detection", () => {
     // At 75% zoom, scrollTop=600 puts page 1's top (626 px) just inside the
     // 50 px grace zone → page 1 (index 1) should become active.
     const ref = createRef<PageViewerHandle>();
-    const { container } = render(
+    const { getByTestId } = render(
       <PageViewer ref={ref} docId={1} pageSizes={PAGES_5} />
     );
-    const scrollEl = container.firstElementChild as HTMLDivElement;
-    mockGeometry(scrollEl, 3066, 800, 600);
+    const scrollEl = getByTestId("scroll-container");
+    mockGeometry(scrollEl as HTMLElement, 3066, 800, 600);
 
     await act(async () => {
       scrollEl.dispatchEvent(new Event("scroll"));

--- a/src/components/PageViewer.test.tsx
+++ b/src/components/PageViewer.test.tsx
@@ -4,6 +4,10 @@ import { vi, describe, it, expect, beforeEach } from "vitest";
 import { PageViewer, PageViewerHandle } from "./PageViewer";
 import { useAppStore } from "@/store";
 
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
 // Avoid virtualizer complexity in unit tests — we only care about the scroll
 // detection logic, not layout.
 vi.mock("@tanstack/react-virtual", () => ({

--- a/src/components/PageViewer.tsx
+++ b/src/components/PageViewer.tsx
@@ -2,7 +2,9 @@ import React, { useEffect, useImperativeHandle, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { cn } from "@/lib/utils";
 import { PageImage } from "./PageImage";
+import { FindBar } from "./FindBar";
 import { useAppStore } from "@/store";
+import { useFindBar } from "@/hooks/useFindBar";
 
 interface PageSize {
   width_pts: number;
@@ -53,6 +55,14 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
     const zoomMode = useAppStore((s) => s.zoomMode);
     const setZoom = useAppStore((s) => s.setZoom);
     const setZoomMode = useAppStore((s) => s.setZoomMode);
+
+    // scrollToPageRef holds the real scroll implementation and is updated every
+    // render so it always captures the latest pageSizes / pageWidthFor values.
+    // useFindBar receives a stable wrapper around this ref so its useCallback
+    // deps don't change on every render. useImperativeHandle delegates to it too.
+    const scrollToPageRef = useRef<(index: number) => void>(() => {});
+    const { state: findState, openFind, closeFind, setQuery, next, prev, highlightsForPage } =
+      useFindBar(docId, (idx) => scrollToPageRef.current(idx));
 
     // Refs for use inside stable closures (virtualizer, event listeners).
     const zoomRef = useRef(zoom);
@@ -180,7 +190,22 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
       return () => el.removeEventListener("wheel", onWheel);
     }, [setZoom, setZoomMode]);
 
-    // Expose scrollToPage to the parent (App) so the sidebar can drive it.
+    // Cmd/Ctrl+F: open find bar. Escape: close find bar (also handled inside FindBar).
+    useEffect(() => {
+      function onKeyDown(e: KeyboardEvent) {
+        if ((e.metaKey || e.ctrlKey) && e.key === "f") {
+          e.preventDefault();
+          openFind();
+        }
+      }
+      document.addEventListener("keydown", onKeyDown);
+      return () => document.removeEventListener("keydown", onKeyDown);
+    }, [openFind]);
+
+    // Keep scrollToPageRef pointing at the real implementation on every render.
+    // Both the imperative handle (sidebar clicks) and useFindBar (match navigation)
+    // call this ref so they always use the latest pageSizes / pageWidthFor values.
+    //
     // We compute the offset directly rather than using virtualizer.scrollToIndex
     // because scrollToIndex triggers a reconcile loop (scheduleScrollReconcile)
     // that spins on requestAnimationFrame waiting for the scroll event to update
@@ -189,29 +214,33 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
     // stabilising — causing the 2-3 s freeze observed at 200%+ zoom.
     // Setting el.scrollTop directly bypasses the loop entirely; the virtualizer's
     // existing scroll listener picks up the change on the next frame as normal.
+    scrollToPageRef.current = (index: number) => {
+      const el = parentRef.current;
+      if (!el) return;
+      let offset = 0;
+      for (let i = 0; i < index; i++) {
+        const { width_pts, height_pts } = pageSizes[i];
+        offset += Math.round((height_pts / width_pts) * pageWidthFor(width_pts)) + PAGE_GAP;
+      }
+      // Set direction before changing scrollTop so the rangeExtractor sees
+      // the correct direction when the virtualizer re-renders on scroll.
+      scrollDirectionRef.current = offset > el.scrollTop ? "down" : "up";
+      // Tell onScroll to use this index directly rather than re-deriving the
+      // active page from the scroll position. This handles two cases:
+      //   1. scrollTop is clamped (offset > maxScrollTop) so position maths
+      //      would pick the wrong page.
+      //   2. The page is already visible and scrollTop doesn't change, so no
+      //      scroll event fires at all — the direct setActivePage below
+      //      handles highlighting immediately in that case.
+      pendingActiveRef.current = index;
+      el.scrollTop = offset;
+      // Optimistic direct set for the no-scroll-event case (page already visible).
+      useAppStore.getState().setActivePage(index);
+    };
+
     useImperativeHandle(ref, () => ({
       scrollToPage(index) {
-        const el = parentRef.current;
-        if (!el) return;
-        let offset = 0;
-        for (let i = 0; i < index; i++) {
-          const { width_pts, height_pts } = pageSizes[i];
-          offset += Math.round((height_pts / width_pts) * pageWidthFor(width_pts)) + PAGE_GAP;
-        }
-        // Set direction before changing scrollTop so the rangeExtractor sees
-        // the correct direction when the virtualizer re-renders on scroll.
-        scrollDirectionRef.current = offset > el.scrollTop ? "down" : "up";
-        // Tell onScroll to use this index directly rather than re-deriving the
-        // active page from the scroll position. This handles two cases:
-        //   1. scrollTop is clamped (offset > maxScrollTop) so position maths
-        //      would pick the wrong page.
-        //   2. The page is already visible and scrollTop doesn't change, so no
-        //      scroll event fires at all — the direct setActivePage below
-        //      handles highlighting immediately in that case.
-        pendingActiveRef.current = index;
-        el.scrollTop = offset;
-        // Optimistic direct set for the no-scroll-event case (page already visible).
-        useAppStore.getState().setActivePage(index);
+        scrollToPageRef.current(index);
       },
     }));
 
@@ -279,51 +308,65 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
         : undefined;
 
     return (
-      <div
-        ref={parentRef}
-        className={cn(
-          "h-full bg-muted",
-          zoomMode === "fit-width" ? "overflow-y-auto" : "overflow-auto"
-        )}
-      >
-        {/* Spacer that gives the scrollbar the correct total height. */}
+      <div className="relative h-full">
         <div
-          className="relative w-full"
-          style={{
-            height: virtualizer.getTotalSize() + PAGE_TOP_GAP,
-            minWidth: manualContentWidth,
-          }}
+          ref={parentRef}
+          data-testid="scroll-container"
+          className={cn(
+            "h-full bg-muted",
+            zoomMode === "fit-width" ? "overflow-y-auto" : "overflow-auto"
+          )}
         >
-          {virtualizer.getVirtualItems().map((item) => {
-            const { width_pts, height_pts } = pageSizes[item.index];
-            const pageWidth =
-              zoomMode === "fit-width"
-                ? Math.max(
-                    (parentRef.current?.clientWidth ?? 800) - PAGE_PADDING_X,
-                    100
-                  )
-                : Math.round((width_pts * zoom) / 100);
+          {/* Spacer that gives the scrollbar the correct total height. */}
+          <div
+            className="relative w-full"
+            style={{
+              height: virtualizer.getTotalSize() + PAGE_TOP_GAP,
+              minWidth: manualContentWidth,
+            }}
+          >
+            {virtualizer.getVirtualItems().map((item) => {
+              const { width_pts, height_pts } = pageSizes[item.index];
+              const pageWidth =
+                zoomMode === "fit-width"
+                  ? Math.max(
+                      (parentRef.current?.clientWidth ?? 800) - PAGE_PADDING_X,
+                      100
+                    )
+                  : Math.round((width_pts * zoom) / 100);
 
-            return (
-              <div
-                key={item.key}
-                className="absolute left-0 right-0"
-                style={{ top: item.start + PAGE_TOP_GAP, paddingBottom: PAGE_GAP }}
-              >
-                {/* mx-auto centers the page when it's narrower than the viewport. */}
-                <div style={{ width: pageWidth, margin: "0 auto" }}>
-                  <PageImage
-                    docId={docId}
-                    pageIndex={item.index}
-                    width={pageWidth}
-                    widthPts={width_pts}
-                    heightPts={height_pts}
-                  />
+              return (
+                <div
+                  key={item.key}
+                  className="absolute left-0 right-0"
+                  style={{ top: item.start + PAGE_TOP_GAP, paddingBottom: PAGE_GAP }}
+                >
+                  {/* mx-auto centers the page when it's narrower than the viewport. */}
+                  <div style={{ width: pageWidth, margin: "0 auto" }}>
+                    <PageImage
+                      docId={docId}
+                      pageIndex={item.index}
+                      width={pageWidth}
+                      widthPts={width_pts}
+                      heightPts={height_pts}
+                      highlights={highlightsForPage(item.index)}
+                    />
+                  </div>
                 </div>
-              </div>
-            );
-          })}
+              );
+            })}
+          </div>
         </div>
+        <FindBar
+          open={findState.open}
+          query={findState.query}
+          matchCount={findState.matches.length}
+          currentMatch={findState.currentMatchIndex}
+          onQueryChange={setQuery}
+          onNext={next}
+          onPrev={prev}
+          onClose={closeFind}
+        />
       </div>
     );
   }

--- a/src/components/PageViewer.tsx
+++ b/src/components/PageViewer.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useImperativeHandle, useRef } from "react";
+import React, { useCallback, useEffect, useImperativeHandle, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { listen } from "@tauri-apps/api/event";
 import { cn } from "@/lib/utils";
 import { PageImage } from "./PageImage";
 import { FindBar } from "./FindBar";
@@ -61,8 +62,15 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
     // useFindBar receives a stable wrapper around this ref so its useCallback
     // deps don't change on every render. useImperativeHandle delegates to it too.
     const scrollToPageRef = useRef<(index: number) => void>(() => {});
+    // Stable wrapper: identity never changes so useFindBar's useCallback deps
+    // don't invalidate on every render, even though scrollToPageRef.current
+    // is updated every render with the latest pageSizes / pageWidthFor values.
+    const stableScrollToPage = useCallback(
+      (idx: number) => scrollToPageRef.current(idx),
+      []
+    );
     const { state: findState, openFind, closeFind, setQuery, next, prev, highlightsForPage } =
-      useFindBar(docId, (idx) => scrollToPageRef.current(idx));
+      useFindBar(docId, stableScrollToPage);
 
     // Refs for use inside stable closures (virtualizer, event listeners).
     const zoomRef = useRef(zoom);
@@ -200,6 +208,14 @@ export const PageViewer = React.forwardRef<PageViewerHandle, Props>(
       }
       document.addEventListener("keydown", onKeyDown);
       return () => document.removeEventListener("keydown", onKeyDown);
+    }, [openFind]);
+
+    // Edit → Find… menu item: same as Cmd+F.
+    useEffect(() => {
+      const unlisten = listen<void>("menu-find", () => openFind());
+      return () => {
+        unlisten.then((fn) => fn());
+      };
     }, [openFind]);
 
     // Keep scrollToPageRef pointing at the real implementation on every render.

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,3 +1,4 @@
+import { AlertTriangle } from "lucide-react";
 import { useAppStore } from "@/store";
 import {
   Tooltip,
@@ -37,7 +38,7 @@ export function StatusBar({ pageCount }: StatusBarProps) {
                 style={{ visibility: activePageScanned ? "visible" : "hidden" }}
                 aria-label="Scanned page"
               >
-                ⚠
+                <AlertTriangle className="h-3 w-3" />
               </span>
             </TooltipTrigger>
             <TooltipContent side="top">

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,4 +1,10 @@
 import { useAppStore } from "@/store";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface StatusBarProps {
   pageCount: number | undefined;
@@ -9,6 +15,7 @@ export function StatusBar({ pageCount }: StatusBarProps) {
   const zoom = useAppStore((s) => s.zoom);
   const zoomMode = useAppStore((s) => s.zoomMode);
   const isDirty = useAppStore((s) => s.isDirty);
+  const activePageScanned = useAppStore((s) => s.activePageScanned);
 
   if (pageCount == null) {
     return <footer className="h-6 shrink-0 border-t bg-muted/40" />;
@@ -20,7 +27,25 @@ export function StatusBar({ pageCount }: StatusBarProps) {
         {isDirty && <span className="mr-1">•</span>}
         Page {activePage + 1} of {pageCount}
       </span>
-      <span>
+      <span className="flex items-center gap-2">
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              {/* Invisible placeholder keeps layout stable when not scanned */}
+              <span
+                className="text-amber-500"
+                style={{ visibility: activePageScanned ? "visible" : "hidden" }}
+                aria-label="Scanned page"
+              >
+                ⚠
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              This page is a scanned image — text selection is unavailable. OCR
+              support is coming in a future update.
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
         {zoomMode === "fit-width" ? "Fit" : `${zoom}%`}
       </span>
     </footer>

--- a/src/components/TextOverlay.test.tsx
+++ b/src/components/TextOverlay.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { TextOverlay } from "./TextOverlay";
+
+vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: vi.fn() }));
+
+const word = (overrides = {}) => ({
+  text: "hello",
+  x: 0.1,
+  y: 0.2,
+  width: 0.15,
+  height: 0.04,
+  is_url: false,
+  ...overrides,
+});
+
+const getWordSpans = (container: HTMLElement) =>
+  container.querySelectorAll("[data-word]");
+
+describe("TextOverlay", () => {
+  it("renders nothing when words array is empty", () => {
+    const { container } = render(<TextOverlay words={[]} highlights={new Set()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders one span per word", () => {
+    const { container } = render(
+      <TextOverlay
+        words={[word({ text: "Hello" }), word({ text: "World" })]}
+        highlights={new Set()}
+      />
+    );
+    expect(getWordSpans(container)).toHaveLength(2);
+  });
+
+  it("sets percentage-based inline styles from word coordinates", () => {
+    const { container } = render(
+      <TextOverlay
+        words={[word({ x: 0.1, y: 0.2, width: 0.15, height: 0.04 })]}
+        highlights={new Set()}
+      />
+    );
+    const span = getWordSpans(container)[0] as HTMLElement;
+    expect(span).toHaveStyle({
+      left: "10%",
+      top: "20%",
+      width: "15%",
+      height: "4%",
+    });
+  });
+
+  it("applies highlight class to words in highlights set", () => {
+    const { container } = render(
+      <TextOverlay
+        words={[word({ text: "motion" }), word({ text: "court" })]}
+        highlights={new Set([0])}
+      />
+    );
+    const spans = getWordSpans(container);
+    expect(spans[0].classList.toString()).toMatch(/highlight/);
+    expect(spans[1].classList.toString()).not.toMatch(/highlight/);
+  });
+
+  it("renders URL words with data-url attribute", () => {
+    const { container } = render(
+      <TextOverlay
+        words={[word({ text: "https://example.com", is_url: true })]}
+        highlights={new Set()}
+      />
+    );
+    const span = getWordSpans(container)[0];
+    expect(span).toHaveAttribute("data-url", "https://example.com");
+  });
+
+  it("opens URL in system browser when URL span is clicked", async () => {
+    const { openUrl } = await import("@tauri-apps/plugin-opener");
+    const user = userEvent.setup();
+    const { container } = render(
+      <TextOverlay
+        words={[word({ text: "https://example.com", is_url: true })]}
+        highlights={new Set()}
+      />
+    );
+    await user.click(getWordSpans(container)[0] as HTMLElement);
+    expect(openUrl).toHaveBeenCalledWith("https://example.com");
+  });
+});

--- a/src/components/TextOverlay.tsx
+++ b/src/components/TextOverlay.tsx
@@ -67,7 +67,7 @@ export function TextOverlay({ words, highlights }: Props) {
               height: `${word.height * 100}%`,
               color: "transparent",
               cursor: isUrl ? "pointer" : "text",
-              pointerEvents: isUrl || isHighlighted ? "auto" : "none",
+              pointerEvents: "auto",
               // Semi-transparent yellow for find matches.
               backgroundColor: isHighlighted ? "rgba(250, 204, 21, 0.4)" : undefined,
               // Prevent layout-affecting whitespace.

--- a/src/components/TextOverlay.tsx
+++ b/src/components/TextOverlay.tsx
@@ -1,0 +1,84 @@
+import { openUrl } from "@tauri-apps/plugin-opener";
+
+export interface WordBox {
+  text: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  is_url: boolean;
+}
+
+interface Props {
+  words: WordBox[];
+  /** Word indices (into the words array) that should be highlighted as find matches. */
+  highlights: Set<number>;
+}
+
+/**
+ * Invisible text overlay positioned absolutely over a page image.
+ *
+ * Each word is rendered as a transparent <span> at the corresponding
+ * percentage position so the browser handles text selection, copy, and
+ * cursor natively. Highlight spans get a semi-transparent yellow background
+ * for find-in-document matches. URL spans open in the system browser on click.
+ *
+ * Coordinates are normalized [0.0, 1.0] with top-left origin — multiply by
+ * 100 to get CSS percentage values. Zoom and resize are free: the overlay
+ * stretches with the page image via `inset: 0`.
+ */
+export function TextOverlay({ words, highlights }: Props) {
+  if (words.length === 0) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        inset: 0,
+        pointerEvents: "none",
+        userSelect: "text",
+        overflow: "hidden",
+      }}
+    >
+      {words.map((word, idx) => {
+        const isHighlighted = highlights.has(idx);
+        const isUrl = word.is_url;
+
+        return (
+          <span
+            key={idx}
+            data-word={word.text}
+            data-url={isUrl ? word.text : undefined}
+            onClick={
+              isUrl
+                ? (e) => {
+                    e.stopPropagation();
+                    openUrl(word.text);
+                  }
+                : undefined
+            }
+            className={isHighlighted ? "highlight" : undefined}
+            style={{
+              position: "absolute",
+              left: `${word.x * 100}%`,
+              top: `${word.y * 100}%`,
+              width: `${word.width * 100}%`,
+              height: `${word.height * 100}%`,
+              color: "transparent",
+              cursor: isUrl ? "pointer" : "text",
+              pointerEvents: isUrl || isHighlighted ? "auto" : "none",
+              // Semi-transparent yellow for find matches.
+              backgroundColor: isHighlighted ? "rgba(250, 204, 21, 0.4)" : undefined,
+              // Prevent layout-affecting whitespace.
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+            }}
+          >
+            {word.text}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/TextOverlay.tsx
+++ b/src/components/TextOverlay.tsx
@@ -36,7 +36,6 @@ export function TextOverlay({ words, highlights }: Props) {
       style={{
         position: "absolute",
         inset: 0,
-        pointerEvents: "none",
         userSelect: "text",
         overflow: "hidden",
       }}

--- a/src/hooks/useFindBar.test.ts
+++ b/src/hooks/useFindBar.test.ts
@@ -1,0 +1,207 @@
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { useFindBar } from "./useFindBar";
+import { invoke } from "@tauri-apps/api/core";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+const MATCH_P0 = { page_index: 0, word_indices: [1, 2] };
+const MATCH_P2 = { page_index: 2, word_indices: [5] };
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("useFindBar — initial state", () => {
+  it("starts closed with empty query and no matches", () => {
+    const { result } = renderHook(() => useFindBar(1, vi.fn()));
+    expect(result.current.state.open).toBe(false);
+    expect(result.current.state.query).toBe("");
+    expect(result.current.state.matches).toEqual([]);
+    expect(result.current.state.currentMatchIndex).toBe(0);
+  });
+});
+
+describe("useFindBar — open / close", () => {
+  it("openFind sets open=true", () => {
+    const { result } = renderHook(() => useFindBar(1, vi.fn()));
+    act(() => result.current.openFind());
+    expect(result.current.state.open).toBe(true);
+  });
+
+  it("closeFind resets all state", () => {
+    const { result } = renderHook(() => useFindBar(1, vi.fn()));
+    act(() => result.current.openFind());
+    act(() => result.current.closeFind());
+    expect(result.current.state.open).toBe(false);
+    expect(result.current.state.query).toBe("");
+    expect(result.current.state.matches).toEqual([]);
+  });
+});
+
+describe("useFindBar — setQuery and debounced search", () => {
+  it("updates query immediately", () => {
+    const { result } = renderHook(() => useFindBar(1, vi.fn()));
+    act(() => result.current.setQuery("hello"));
+    expect(result.current.state.query).toBe("hello");
+  });
+
+  it("does not invoke search before debounce elapses", () => {
+    renderHook(() => useFindBar(1, vi.fn()));
+    act(() => {
+      // setQuery is accessed via result inside the hook closure; we just call invoke directly
+    });
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("invokes search_document after 200ms debounce", async () => {
+    (invoke as Mock).mockResolvedValue([MATCH_P0]);
+    const { result } = renderHook(() => useFindBar(1, vi.fn()));
+    act(() => result.current.setQuery("hello"));
+    expect(invoke).not.toHaveBeenCalled();
+    await act(async () => { vi.advanceTimersByTime(200); });
+    expect(invoke).toHaveBeenCalledWith("search_document", { docId: 1, query: "hello" });
+  });
+
+  it("debounces rapid typing — only the last query fires", async () => {
+    (invoke as Mock).mockResolvedValue([]);
+    const { result } = renderHook(() => useFindBar(1, vi.fn()));
+    act(() => result.current.setQuery("h"));
+    act(() => result.current.setQuery("he"));
+    act(() => result.current.setQuery("hel"));
+    await act(async () => { vi.advanceTimersByTime(200); });
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledWith("search_document", { docId: 1, query: "hel" });
+  });
+
+  it("populates matches and resets currentMatchIndex after search", async () => {
+    (invoke as Mock).mockResolvedValue([MATCH_P0, MATCH_P2]);
+    const { result } = renderHook(() => useFindBar(1, vi.fn()));
+    await act(async () => {
+      result.current.setQuery("test");
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.state.matches).toEqual([MATCH_P0, MATCH_P2]);
+    expect(result.current.state.currentMatchIndex).toBe(0);
+  });
+
+  it("invokes search_document when docId is 0 (first document)", async () => {
+    (invoke as Mock).mockResolvedValue([MATCH_P0]);
+    const { result } = renderHook(() => useFindBar(0, vi.fn()));
+    act(() => result.current.setQuery("hello"));
+    await act(async () => { vi.advanceTimersByTime(200); });
+    expect(invoke).toHaveBeenCalledWith("search_document", { docId: 0, query: "hello" });
+  });
+
+  it("clears matches when query is empty string", async () => {
+    (invoke as Mock).mockResolvedValue([MATCH_P0]);
+    const { result } = renderHook(() => useFindBar(1, vi.fn()));
+    await act(async () => {
+      result.current.setQuery("test");
+      vi.advanceTimersByTime(200);
+    });
+    await act(async () => {
+      result.current.setQuery("");
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.state.matches).toEqual([]);
+    expect(invoke).toHaveBeenCalledTimes(1); // empty query short-circuits
+  });
+
+  it("clears matches on error", async () => {
+    (invoke as Mock).mockRejectedValue(new Error("fail"));
+    const { result } = renderHook(() => useFindBar(1, vi.fn()));
+    await act(async () => {
+      result.current.setQuery("err");
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.state.matches).toEqual([]);
+  });
+});
+
+describe("useFindBar — next / prev", () => {
+  async function hookWithMatches() {
+    (invoke as Mock).mockResolvedValue([MATCH_P0, MATCH_P2]);
+    const scrollToPage = vi.fn();
+    const { result } = renderHook(() => useFindBar(1, scrollToPage));
+    await act(async () => {
+      result.current.setQuery("test");
+      vi.advanceTimersByTime(200);
+    });
+    return { result, scrollToPage };
+  }
+
+  it("next advances currentMatchIndex", async () => {
+    const { result } = await hookWithMatches();
+    act(() => result.current.next());
+    expect(result.current.state.currentMatchIndex).toBe(1);
+  });
+
+  it("next wraps around to 0 from last match", async () => {
+    const { result } = await hookWithMatches();
+    act(() => result.current.next()); // → 1
+    act(() => result.current.next()); // → 0 (wrap)
+    expect(result.current.state.currentMatchIndex).toBe(0);
+  });
+
+  it("prev decrements currentMatchIndex", async () => {
+    const { result } = await hookWithMatches();
+    act(() => result.current.next()); // → 1
+    act(() => result.current.prev()); // → 0
+    expect(result.current.state.currentMatchIndex).toBe(0);
+  });
+
+  it("prev wraps from 0 to last match", async () => {
+    const { result } = await hookWithMatches();
+    act(() => result.current.prev()); // → 1 (wrap from 0)
+    expect(result.current.state.currentMatchIndex).toBe(1);
+  });
+
+  it("next calls scrollToPage with the match's page_index — outside setState", async () => {
+    const { result, scrollToPage } = await hookWithMatches();
+    act(() => result.current.next());
+    // scrollToPage should be called with page_index of match index 1 (MATCH_P2)
+    expect(scrollToPage).toHaveBeenCalledWith(MATCH_P2.page_index);
+  });
+
+  it("prev calls scrollToPage outside setState", async () => {
+    const { result, scrollToPage } = await hookWithMatches();
+    act(() => result.current.prev()); // wraps to index 1 (MATCH_P2)
+    expect(scrollToPage).toHaveBeenCalledWith(MATCH_P2.page_index);
+  });
+
+  it("next is a no-op when there are no matches", () => {
+    const scrollToPage = vi.fn();
+    const { result } = renderHook(() => useFindBar(1, scrollToPage));
+    act(() => result.current.next());
+    expect(scrollToPage).not.toHaveBeenCalled();
+    expect(result.current.state.currentMatchIndex).toBe(0);
+  });
+});
+
+describe("useFindBar — highlightsForPage", () => {
+  it("returns empty Set for pages with no matches", async () => {
+    (invoke as Mock).mockResolvedValue([MATCH_P0]);
+    const { result } = renderHook(() => useFindBar(1, vi.fn()));
+    await act(async () => {
+      result.current.setQuery("x");
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.highlightsForPage(99)).toEqual(new Set());
+  });
+
+  it("returns word_indices Set for a page with matches", async () => {
+    (invoke as Mock).mockResolvedValue([MATCH_P0]);
+    const { result } = renderHook(() => useFindBar(1, vi.fn()));
+    await act(async () => {
+      result.current.setQuery("x");
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.highlightsForPage(0)).toEqual(new Set([1, 2]));
+  });
+});

--- a/src/hooks/useFindBar.ts
+++ b/src/hooks/useFindBar.ts
@@ -1,0 +1,111 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useRef, useState } from "react";
+
+export interface SearchMatch {
+  page_index: number;
+  word_indices: number[];
+}
+
+interface FindBarState {
+  open: boolean;
+  query: string;
+  matches: SearchMatch[];
+  currentMatchIndex: number;
+}
+
+/**
+ * Manages find-in-document state and search invocation.
+ *
+ * Returns:
+ * - `state` — current find bar state
+ * - `openFind()` — open the find bar (call on Cmd+F)
+ * - `closeFind()` — close and reset
+ * - `setQuery(q)` — update query, triggers a debounced search
+ * - `next()` / `prev()` — advance match index and scroll to the page
+ * - `highlightsForPage(pageIndex)` — Set<number> of word indices to highlight on that page
+ */
+export function useFindBar(docId: number | null, scrollToPage: (index: number) => void) {
+  const [state, setState] = useState<FindBarState>({
+    open: false,
+    query: "",
+    matches: [],
+    currentMatchIndex: 0,
+  });
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const search = useCallback(
+    async (query: string) => {
+      if (!docId || query.trim() === "") {
+        setState((s) => ({ ...s, matches: [], currentMatchIndex: 0 }));
+        return;
+      }
+      try {
+        const matches = await invoke<SearchMatch[]>("search_document", { docId, query });
+        setState((s) => ({ ...s, matches, currentMatchIndex: 0 }));
+        // Scroll to the first match page if any.
+        if (matches.length > 0) {
+          scrollToPage(matches[0].page_index);
+        }
+      } catch {
+        setState((s) => ({ ...s, matches: [], currentMatchIndex: 0 }));
+      }
+    },
+    [docId, scrollToPage]
+  );
+
+  const setQuery = useCallback(
+    (query: string) => {
+      setState((s) => ({ ...s, query }));
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => search(query), 200);
+    },
+    [search]
+  );
+
+  const openFind = useCallback(() => {
+    setState((s) => ({ ...s, open: true }));
+  }, []);
+
+  const closeFind = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    setState({ open: false, query: "", matches: [], currentMatchIndex: 0 });
+  }, []);
+
+  const next = useCallback(() => {
+    setState((s) => {
+      if (s.matches.length === 0) return s;
+      const nextIdx = (s.currentMatchIndex + 1) % s.matches.length;
+      scrollToPage(s.matches[nextIdx].page_index);
+      return { ...s, currentMatchIndex: nextIdx };
+    });
+  }, [scrollToPage]);
+
+  const prev = useCallback(() => {
+    setState((s) => {
+      if (s.matches.length === 0) return s;
+      const prevIdx = (s.currentMatchIndex - 1 + s.matches.length) % s.matches.length;
+      scrollToPage(s.matches[prevIdx].page_index);
+      return { ...s, currentMatchIndex: prevIdx };
+    });
+  }, [scrollToPage]);
+
+  /** Returns a Set of word indices to highlight on the given page. */
+  const highlightsForPage = useCallback(
+    (pageIndex: number): Set<number> => {
+      const match = state.matches.find((m) => m.page_index === pageIndex);
+      return match ? new Set(match.word_indices) : new Set();
+    },
+    [state.matches]
+  );
+
+  return {
+    state,
+    openFind,
+    closeFind,
+    setQuery,
+    next,
+    prev,
+    highlightsForPage,
+  };
+}

--- a/src/hooks/useFindBar.ts
+++ b/src/hooks/useFindBar.ts
@@ -32,11 +32,18 @@ export function useFindBar(docId: number | null, scrollToPage: (index: number) =
     currentMatchIndex: 0,
   });
 
+  // Keep a ref to the current state so next()/prev() can read matches and
+  // currentMatchIndex synchronously without a stale closure and without
+  // placing `state` in their useCallback dep arrays (which would recreate
+  // them on every render).
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const search = useCallback(
     async (query: string) => {
-      if (!docId || query.trim() === "") {
+      if (docId == null || query.trim() === "") {
         setState((s) => ({ ...s, matches: [], currentMatchIndex: 0 }));
         return;
       }
@@ -73,21 +80,19 @@ export function useFindBar(docId: number | null, scrollToPage: (index: number) =
   }, []);
 
   const next = useCallback(() => {
-    setState((s) => {
-      if (s.matches.length === 0) return s;
-      const nextIdx = (s.currentMatchIndex + 1) % s.matches.length;
-      scrollToPage(s.matches[nextIdx].page_index);
-      return { ...s, currentMatchIndex: nextIdx };
-    });
+    const s = stateRef.current;
+    if (s.matches.length === 0) return;
+    const nextIdx = (s.currentMatchIndex + 1) % s.matches.length;
+    setState((prev) => ({ ...prev, currentMatchIndex: nextIdx }));
+    scrollToPage(s.matches[nextIdx].page_index);
   }, [scrollToPage]);
 
   const prev = useCallback(() => {
-    setState((s) => {
-      if (s.matches.length === 0) return s;
-      const prevIdx = (s.currentMatchIndex - 1 + s.matches.length) % s.matches.length;
-      scrollToPage(s.matches[prevIdx].page_index);
-      return { ...s, currentMatchIndex: prevIdx };
-    });
+    const s = stateRef.current;
+    if (s.matches.length === 0) return;
+    const prevIdx = (s.currentMatchIndex - 1 + s.matches.length) % s.matches.length;
+    setState((prev) => ({ ...prev, currentMatchIndex: prevIdx }));
+    scrollToPage(s.matches[prevIdx].page_index);
   }, [scrollToPage]);
 
   /** Returns a Set of word indices to highlight on the given page. */

--- a/src/hooks/useKeyboardNav.ts
+++ b/src/hooks/useKeyboardNav.ts
@@ -13,7 +13,7 @@ function isSidebarVisible(el: HTMLElement): boolean {
   return el.closest('[data-state="collapsed"]') === null;
 }
 
-function isInputFocused(target: EventTarget | null): boolean {
+export function isInputFocused(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
   const tag = target.tagName;
   return (

--- a/src/hooks/useTextLayer.test.ts
+++ b/src/hooks/useTextLayer.test.ts
@@ -1,0 +1,111 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { useTextLayer, invalidateTextLayerCache } from "./useTextLayer";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+const MOCK_RESPONSE = { words: [{ text: "Hello", x: 0.1, y: 0.1, width: 0.1, height: 0.05, is_url: false }], scanned: false };
+
+// Capture the latest document-mutated listener so tests can fire it.
+let mutationListener: ((event: { payload: number }) => void) | null = null;
+beforeEach(() => {
+  mutationListener = null;
+  (listen as Mock).mockImplementation((_event: string, handler: (e: { payload: number }) => void) => {
+    mutationListener = handler;
+    return Promise.resolve(vi.fn());
+  });
+  (invoke as Mock).mockResolvedValue(MOCK_RESPONSE);
+});
+
+afterEach(() => {
+  invalidateTextLayerCache(1);
+  invalidateTextLayerCache(2);
+  vi.clearAllMocks();
+});
+
+describe("useTextLayer — initial state", () => {
+  it("starts with loading=true and empty words when cache is cold", () => {
+    const { result } = renderHook(() => useTextLayer(1, 0));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.words).toEqual([]);
+    expect(result.current.scanned).toBe(false);
+  });
+
+  it("returns null doc as loading=true, words=[] without invoking", () => {
+    const { result } = renderHook(() => useTextLayer(null, 0));
+    expect(result.current.loading).toBe(true);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});
+
+describe("useTextLayer — fetch", () => {
+  it("calls get_text_layer with docId and pageIndex", async () => {
+    renderHook(() => useTextLayer(1, 3));
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith("get_text_layer", { docId: 1, pageIndex: 3 }));
+  });
+
+  it("resolves to words and loading=false after fetch", async () => {
+    const { result } = renderHook(() => useTextLayer(1, 0));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.words).toEqual(MOCK_RESPONSE.words);
+    expect(result.current.scanned).toBe(false);
+  });
+
+  it("sets loading=false and returns empty words on fetch error", async () => {
+    (invoke as Mock).mockRejectedValueOnce(new Error("fail"));
+    const { result } = renderHook(() => useTextLayer(1, 0));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.words).toEqual([]);
+  });
+});
+
+describe("useTextLayer — cache", () => {
+  it("skips the IPC call on re-render when cache is warm", async () => {
+    const { result, rerender } = renderHook(() => useTextLayer(1, 0));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(invoke).toHaveBeenCalledTimes(1);
+    rerender();
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns loading=false immediately on mount when cache is warm", async () => {
+    // Warm the cache with a first render.
+    const { unmount } = renderHook(() => useTextLayer(1, 0));
+    await waitFor(() => expect(invoke).toHaveBeenCalledTimes(1));
+    unmount();
+    // Second mount: cache is warm, should be loading=false on first render.
+    const { result } = renderHook(() => useTextLayer(1, 0));
+    expect(result.current.loading).toBe(false);
+    expect(result.current.words).toEqual(MOCK_RESPONSE.words);
+  });
+});
+
+describe("useTextLayer — document-mutated", () => {
+  it("re-fetches after a mutation event for the same docId", async () => {
+    const { result } = renderHook(() => useTextLayer(1, 0));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(invoke).toHaveBeenCalledTimes(1);
+
+    // Fire the mutation event.
+    act(() => { mutationListener?.({ payload: 1 }); });
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+  });
+
+  it("ignores mutation events for a different docId", async () => {
+    const { result } = renderHook(() => useTextLayer(1, 0));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => { mutationListener?.({ payload: 2 }); }); // different doc
+
+    // No second invocation.
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/src/hooks/useTextLayer.ts
+++ b/src/hooks/useTextLayer.ts
@@ -1,0 +1,92 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { useEffect, useRef, useState } from "react";
+import type { WordBox } from "@/components/TextOverlay";
+
+interface TextLayerResponse {
+  words: WordBox[];
+  scanned: boolean;
+}
+
+/** Module-level cache: key is `"${docId}:${pageIndex}"`. */
+const cache = new Map<string, TextLayerResponse>();
+
+/** Clears all cached entries for a given document (call after mutations). */
+export function invalidateTextLayerCache(docId: number) {
+  for (const key of cache.keys()) {
+    if (key.startsWith(`${docId}:`)) {
+      cache.delete(key);
+    }
+  }
+}
+
+/**
+ * Fetches and caches the word-level text layer for a single page.
+ *
+ * Returns `{ words, scanned, loading }`:
+ * - `words` — word boxes in normalized [0, 1] coordinates
+ * - `scanned` — true when the page has no embedded text
+ * - `loading` — true while the first fetch is in flight
+ *
+ * The result is cached so repeated renders (e.g. zoom changes) don't re-fetch.
+ * Cache is invalidated when a `document-mutated` Tauri event fires for this doc.
+ */
+export function useTextLayer(docId: number | null, pageIndex: number) {
+  const cacheKey = docId != null ? `${docId}:${pageIndex}` : null;
+  const [result, setResult] = useState<TextLayerResponse>(() =>
+    cacheKey && cache.has(cacheKey) ? cache.get(cacheKey)! : { words: [], scanned: false }
+  );
+  const [loading, setLoading] = useState(
+    () => cacheKey == null || !cache.has(cacheKey)
+  );
+
+  // Track the current key so the effect cleanup can ignore stale responses.
+  const keyRef = useRef(cacheKey);
+  keyRef.current = cacheKey;
+
+  useEffect(() => {
+    if (docId == null) return;
+    const key = `${docId}:${pageIndex}`;
+
+    if (cache.has(key)) {
+      setResult(cache.get(key)!);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+
+    invoke<TextLayerResponse>("get_text_layer", {
+      docId,
+      pageIndex,
+    })
+      .then((res) => {
+        if (keyRef.current !== key) return; // stale
+        cache.set(key, res);
+        setResult(res);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (keyRef.current !== key) return;
+        setLoading(false);
+      });
+  }, [docId, pageIndex]);
+
+  // Listen for document mutation events and invalidate the cache for this doc.
+  useEffect(() => {
+    if (docId == null) return;
+    const unlisten = listen<number>("document-mutated", (event) => {
+      if (event.payload === docId) {
+        invalidateTextLayerCache(docId);
+        // Re-trigger fetch by clearing local state.
+        setResult({ words: [], scanned: false });
+        setLoading(true);
+      }
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [docId]);
+
+  return { ...result, loading };
+}

--- a/src/hooks/useTextLayer.ts
+++ b/src/hooks/useTextLayer.ts
@@ -39,6 +39,8 @@ export function useTextLayer(docId: number | null, pageIndex: number) {
   const [loading, setLoading] = useState(
     () => cacheKey == null || !cache.has(cacheKey)
   );
+  // Incrementing this triggers the fetch effect to re-run after mutation.
+  const [fetchTrigger, setFetchTrigger] = useState(0);
 
   // Track the current key so the effect cleanup can ignore stale responses.
   const keyRef = useRef(cacheKey);
@@ -70,7 +72,7 @@ export function useTextLayer(docId: number | null, pageIndex: number) {
         if (keyRef.current !== key) return;
         setLoading(false);
       });
-  }, [docId, pageIndex]);
+  }, [docId, pageIndex, fetchTrigger]);
 
   // Listen for document mutation events and invalidate the cache for this doc.
   useEffect(() => {
@@ -78,9 +80,9 @@ export function useTextLayer(docId: number | null, pageIndex: number) {
     const unlisten = listen<number>("document-mutated", (event) => {
       if (event.payload === docId) {
         invalidateTextLayerCache(docId);
-        // Re-trigger fetch by clearing local state.
-        setResult({ words: [], scanned: false });
-        setLoading(true);
+        // Bump the trigger to re-run the fetch effect (deps [docId, pageIndex]
+        // haven't changed, so this is the only way to force a re-fetch).
+        setFetchTrigger((n) => n + 1);
       }
     });
     return () => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,22 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./App.css";
 import App from "./App";
+import { useAppStore } from "./store";
+
+// In dev builds, expose a helper so the DevTools console can call Tauri
+// commands without needing to know the docId ahead of time.
+if (import.meta.env.DEV) {
+  (window as Record<string, unknown>).__collateDebug = {
+    getDocId: () => useAppStore.getState().activeDocId,
+    invoke: (cmd: string, args?: Record<string, unknown>) => {
+      const docId = useAppStore.getState().activeDocId;
+      return (window as Record<string, unknown>).__TAURI_INTERNALS__
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ? (window as any).__TAURI_INTERNALS__.invoke(cmd, { docId, pageIndex: 0, ...args })
+        : Promise.reject("Tauri IPC not found");
+    },
+  };
+}
 
 document.addEventListener("contextmenu", (e) => {
   // Allow the native context menu in text inputs so right-click → Paste works.

--- a/src/store.ts
+++ b/src/store.ts
@@ -14,7 +14,6 @@ export interface DocViewState {
   selectedPages: ReadonlySet<number>;
   isDirty: boolean;
   selectionAnchor: number | null;
-  activePageScanned: boolean;
 }
 
 export const DEFAULT_DOC_VIEW_STATE: DocViewState = {
@@ -24,7 +23,6 @@ export const DEFAULT_DOC_VIEW_STATE: DocViewState = {
   selectedPages: new Set(),
   isDirty: false,
   selectionAnchor: null,
-  activePageScanned: false,
 };
 
 export interface TabEntry {
@@ -94,7 +92,6 @@ function captureViewState(s: AppStore): DocViewState {
     selectedPages: s.selectedPages,
     isDirty: s.isDirty,
     selectionAnchor: s.selectionAnchor,
-    activePageScanned: s.activePageScanned,
   };
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -14,6 +14,7 @@ export interface DocViewState {
   selectedPages: ReadonlySet<number>;
   isDirty: boolean;
   selectionAnchor: number | null;
+  activePageScanned: boolean;
 }
 
 export const DEFAULT_DOC_VIEW_STATE: DocViewState = {
@@ -23,6 +24,7 @@ export const DEFAULT_DOC_VIEW_STATE: DocViewState = {
   selectedPages: new Set(),
   isDirty: false,
   selectionAnchor: null,
+  activePageScanned: false,
 };
 
 export interface TabEntry {
@@ -49,6 +51,9 @@ interface AppStore {
   // Active doc view state (top-level live copy; saved/restored on tab switch)
   activePage: number;
   setActivePage(index: number): void;
+  /** True when the currently active page has no embedded text (scanned image). */
+  activePageScanned: boolean;
+  setActivePageScanned(scanned: boolean): void;
   zoom: number;
   setZoom(zoom: number): void;
   zoomMode: ZoomMode;
@@ -89,6 +94,7 @@ function captureViewState(s: AppStore): DocViewState {
     selectedPages: s.selectedPages,
     isDirty: s.isDirty,
     selectionAnchor: s.selectionAnchor,
+    activePageScanned: s.activePageScanned,
   };
 }
 
@@ -189,7 +195,9 @@ export const useAppStore = create<AppStore>()(
 
       // Active doc view state
       activePage: 0,
-      setActivePage: (index) => set({ activePage: index }),
+      setActivePage: (index) => set({ activePage: index, activePageScanned: false }),
+      activePageScanned: false,
+      setActivePageScanned: (scanned) => set({ activePageScanned: scanned }),
       zoom: 75,
       setZoom: (zoom) => set({ zoom }),
       zoomMode: "manual",


### PR DESCRIPTION
Closes #17

## Summary

- **Rust `get_text_layer` command**: extracts word-level bounding boxes from PDFium, normalises coordinates to [0,1] with top-left origin, detects URLs (`http://`, `https://`, `www.`), flags scanned pages (0 embedded chars → `scanned: true`)
- **Rust `search_document` command**: case-insensitive substring search across all pages, returns page index + word indices for highlight mapping
- **`TextOverlay` component**: invisible `position: absolute` spans over each page image — browser handles selection, copy, and cursor natively; yellow semi-transparent background on find matches; URL spans open system browser on click
- **`FindBar` component + `useFindBar` hook**: floating panel at top-right of viewer (Cmd/Ctrl+F to open, Escape to close), debounced 200ms search, N-of-M match display, prev/next navigation (arrows + Enter/Shift+Enter)
- **`useTextLayer` hook**: per-page module-level cache keyed by `docId:pageIndex`, cleared on `document-mutated` Tauri event
- **`StatusBar`**: amber ⚠ indicator with shadcn Tooltip when the active page is scanned — invisible (not hidden) to avoid layout shift
- **`PageViewer`**: `scrollToPageRef` pattern assigns the real scroll implementation every render so both sidebar clicks and find navigation always use fresh `pageSizes`; `FindBar` mounted in an outer `position: relative` wrapper

## Test plan

- [ ] 10 Rust integration tests in `src-tauri/tests/text_layer.rs` (word extraction, coordinate normalisation, word grouping, scanned detection, URL detection, search)
- [ ] 5 `TextOverlay` unit tests — span count, percentage styles, highlight class, URL attribute, click handler
- [ ] 8 `FindBar` unit tests — open/closed state, match count, query change, next/prev/close callbacks, Escape key
- [ ] All 267 frontend tests pass (`make test-frontend`)
- [ ] All 37 Rust tests pass (`make test-rust`)
- [ ] Manual: open text PDF → text is selectable on all pages
- [ ] Manual: open scanned PDF → ⚠ appears in status bar with tooltip
- [ ] Manual: Cmd+F opens find bar; typing highlights matches; next/prev scrolls to correct page
- [ ] Manual: Escape closes find bar
- [ ] Manual: click a URL in text → opens system browser
- [ ] Manual: zoom in/out — overlay tracks page precisely